### PR TITLE
[Phase 2] 워크플로우 재구성과 변환·분석 경로 확장

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,54 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# HWPX Editor (Vercel)
 
-## Getting Started
+Vercel에 바로 배포 가능한 HWPX 편집기입니다.
 
-First, run the development server:
+- HWPX 업로드 후 텍스트 노드 탐색
+- 스타일 속성 카탈로그 확인
+- 스타일 유지 텍스트 수정 큐 적용
+- AI 제안 생성 (`/api/suggest`)
+- 일괄 섹션 재작성 (`/api/suggest-batch`)
+- 원문/제안 diff 프리뷰
+- `{{TITLE}}` 같은 플레이스홀더 치환
+
+## Local Run
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+브라우저에서 `http://localhost:3000` 열기
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Vercel Deploy
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+1. GitHub에 `hwpx-report-automation/web` 폴더를 푸시
+2. Vercel에서 프로젝트 Import
+3. Environment Variables에 `OPENAI_API_KEY` 추가
+4. Deploy
 
-## Learn More
+## Notes
 
-To learn more about Next.js, take a look at the following resources:
+- 편집은 XML 텍스트 노드만 바꾸므로 스타일 속성은 유지됩니다.
+- HWPX 내부 XML 구조에 따라 일부 노드는 표시되지 않을 수 있습니다.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Pass Criteria / Tests
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+1. Undo/Redo
+- 기준: 큐 수정 후 `undo -> redo`에서 최종 편집 상태가 동일해야 함
+- 테스트: `src/lib/editor-workflows.test.ts`
 
-## Deploy on Vercel
+2. 섹션 자동 선택
+- 기준: 현재 노드 기준으로 동일 파일 내 `헤딩 ~ 다음 헤딩 전` 범위를 선택해야 함
+- 테스트: `src/lib/editor-workflows.test.ts`
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+3. HWPX 무결성(손상 방지)
+- 기준: 편집 후에도 `mimetype`, `version.xml`, `Contents/content.hpf`가 유지되고 XML 파싱 가능해야 함
+- 테스트: `src/lib/hwpx.test.ts`
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+실행:
+
+```bash
+npm run lint
+npm run test
+npm run build
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,24 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
+        "@tiptap/extension-font-family": "^3.20.0",
         "@tiptap/extension-placeholder": "^3.8.0",
         "@tiptap/extension-table": "^3.8.0",
         "@tiptap/extension-table-cell": "^3.8.0",
         "@tiptap/extension-table-header": "^3.8.0",
         "@tiptap/extension-table-row": "^3.8.0",
+        "@tiptap/extension-text-align": "^3.20.0",
+        "@tiptap/extension-text-style": "^3.20.0",
+        "@tiptap/extension-underline": "^3.20.0",
         "@tiptap/react": "^3.8.0",
         "@tiptap/starter-kit": "^3.8.0",
         "@tiptap/suggestion": "^3.8.0",
         "diff": "^8.0.3",
+        "docx": "^9.5.3",
+        "file-saver": "^2.0.5",
         "jszip": "^3.10.1",
+        "mammoth": "^1.11.0",
         "next": "16.1.6",
         "openai": "^6.22.0",
         "react": "19.2.3",
@@ -26,6 +34,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
+        "@types/file-saver": "^2.0.7",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -44,6 +53,26 @@
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.1.2",
@@ -291,6 +320,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2444,6 +2482,19 @@
         "@tiptap/pm": "^3.20.0"
       }
     },
+    "node_modules/@tiptap/extension-font-family": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-font-family/-/extension-font-family-3.20.0.tgz",
+      "integrity": "sha512-XYR2vXYdeWA/YSr1nVlRw00h524a7Jjp529sti4EnKrQfGmB4LsYzihhcXsbzCxa2ffusWXeA3hbfO9NoTBltg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-text-style": "^3.20.0"
+      }
+    },
     "node_modules/@tiptap/extension-gapcursor": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.20.0.tgz",
@@ -2687,6 +2738,33 @@
         "@tiptap/core": "^3.20.0"
       }
     },
+    "node_modules/@tiptap/extension-text-align": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.20.0.tgz",
+      "integrity": "sha512-4s0r+bovtH6yeGDUD+Ui8j5WOV5koB5P6AuzOMqoLwaFGRSkKf64ly6DXjjmjIgnYCLZN/XO6llaQKVVdvad2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.20.0.tgz",
+      "integrity": "sha512-zyWW1a6W+kaXAn3wv2svJ1XuVMapujftvH7Xn2Q3QmKKiDkO+NiFkrGe8BhMopu8Im51nO3NylIgVA0X1mS1rQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.0"
+      }
+    },
     "node_modules/@tiptap/extension-underline": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.20.0.tgz",
@@ -2856,6 +2934,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
+      "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3626,6 +3711,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3939,6 +4033,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -3960,6 +4074,12 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4402,6 +4522,12 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -4413,6 +4539,65 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/docx": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.5.3.tgz",
+      "integrity": "sha512-uFVrYiN2WKx1an884SS6mRu4JuCO10fpnRGQLYmbYgMLVAqqjrKPc2qMXsGj9JuDVrzdntGRw+y84bSjBxXqew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/docx/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -5240,6 +5425,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5588,6 +5779,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "node_modules/hasown": {
@@ -6261,6 +6462,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6420,6 +6634,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6438,6 +6663,39 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.11.0.tgz",
+      "integrity": "sha512-BcEqqY/BOwIcI1iR5tqyVlqc3KIaMRa4egSoK83YAVrBf6+yqdAAbtUcFDCWX8Zef8/fgNZ6rl4VUv+vVX8ddQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/markdown-it": {
@@ -6515,6 +6773,12 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -6821,6 +7085,12 @@
         }
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6935,6 +7205,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -7576,6 +7855,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -7832,6 +8120,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -8213,6 +8507,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -8433,6 +8733,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.22.0",
@@ -8956,6 +9262,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -8964,6 +9288,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -10,16 +10,24 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
+    "@tiptap/extension-font-family": "^3.20.0",
     "@tiptap/extension-placeholder": "^3.8.0",
     "@tiptap/extension-table": "^3.8.0",
     "@tiptap/extension-table-cell": "^3.8.0",
     "@tiptap/extension-table-header": "^3.8.0",
     "@tiptap/extension-table-row": "^3.8.0",
+    "@tiptap/extension-text-align": "^3.20.0",
+    "@tiptap/extension-text-style": "^3.20.0",
+    "@tiptap/extension-underline": "^3.20.0",
     "@tiptap/react": "^3.8.0",
     "@tiptap/starter-kit": "^3.8.0",
     "@tiptap/suggestion": "^3.8.0",
     "diff": "^8.0.3",
+    "docx": "^9.5.3",
+    "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
+    "mammoth": "^1.11.0",
     "next": "16.1.6",
     "openai": "^6.22.0",
     "react": "19.2.3",
@@ -28,6 +36,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@types/file-saver": "^2.0.7",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/scripts/generate-linkedin-report.ts
+++ b/scripts/generate-linkedin-report.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { JSDOM } from "jsdom";
+import OpenAI from "openai";
+import { applyTextEdits, inspectHwpx, validateHwpxArchive } from "../src/lib/hwpx";
+
+const TARGET_LINE_COUNT = 25;
+
+function fallbackLines(today: string): string[] {
+  return [
+    "LinkedIn 공유용 프로젝트 업데이트",
+    `${today}`,
+    "프로젝트: HWPX Editor for Vercel",
+    "오늘은 HWPX 자동 편집의 실사용성을 검증했습니다.",
+    "1. 오늘 완료한 핵심 작업",
+    "- HWPX 업로드 후 텍스트 노드 탐색 UI 안정화",
+    "- 스타일 카탈로그 기반 편집 흐름 정리",
+    "- 수정 큐 반영 후 HWPX 재생성 품질 점검",
+    "2. AI 기능 고도화",
+    "- 단건 제안 API(/api/suggest) 응답 품질 개선",
+    "- 일괄 제안 API(/api/suggest-batch) 처리 안정화",
+    "- 문맥 보존 중심 프롬프트 규칙 재정비",
+    "3. 안정성 검증",
+    "- XML 텍스트 구간 치환 방식으로 손상 리스크 축소",
+    "- 무결성 검사(mimetype/version.xml/content.hpf) 유지",
+    "- 편집 후 XML 파싱 검증 자동화",
+    "4. 사용자 경험 개선",
+    "- Undo/Redo 흐름과 단축키 동작 확인",
+    "- 헤딩 기반 섹션 자동 선택 정확도 개선",
+    "- 원문/제안 Diff 비교 가독성 보강",
+    "5. 다음 실행 계획",
+    "- 실무 샘플 다건 회귀 테스트 확대",
+    "- 템플릿별 스타일 규칙 사전 정밀화",
+    "- 배포 환경 API 키 연동으로 자동화 확장",
+    "#HWPX #Vercel #DocumentAI #OpenAI #ProductEngineering",
+  ];
+}
+
+type NormalizeResult = {
+  lines: string[];
+  source: "ai" | "mixed" | "fallback";
+};
+
+function normalizeLines(raw: unknown, today: string): NormalizeResult {
+  const fallback = fallbackLines(today);
+  if (!Array.isArray(raw)) {
+    return { lines: fallback, source: "fallback" };
+  }
+
+  const flat = raw
+    .map((item) => String(item ?? ""))
+    .flatMap((item) => item.split(/\r?\n/g))
+    .map((item) => item.replace(/\s+/g, " ").trim())
+    .filter((item) => item.length > 0)
+    .map((item) => item.replace(/^[-*]\s+/, "- "));
+
+  if (flat.length >= TARGET_LINE_COUNT) {
+    return { lines: flat.slice(0, TARGET_LINE_COUNT), source: "ai" };
+  }
+
+  if (flat.length >= 12) {
+    const filled = [...flat];
+    while (filled.length < TARGET_LINE_COUNT) {
+      filled.push(fallback[filled.length]);
+    }
+    return { lines: filled, source: "mixed" };
+  }
+
+  return { lines: fallback, source: "fallback" };
+}
+
+function parseJsonObject(raw: string): { lines?: unknown } {
+  try {
+    return JSON.parse(raw) as { lines?: unknown };
+  } catch {
+    const start = raw.indexOf("{");
+    const end = raw.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      return JSON.parse(raw.slice(start, end + 1)) as { lines?: unknown };
+    }
+    throw new Error("JSON parse failed");
+  }
+}
+
+async function generateLines(
+  client: OpenAI,
+  model: string,
+  today: string,
+): Promise<NormalizeResult> {
+  const completion = await client.chat.completions.create({
+    model,
+    temperature: 0.4,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "너는 B2B SaaS/개발자 제품의 링크드인 게시글 작성자다. 반드시 JSON 객체로만 답하고, 키는 lines 하나만 사용한다.",
+      },
+      {
+        role: "user",
+        content:
+          `아래 조건으로 한국어 보고서 라인 25개를 작성해줘.\n` +
+          `- 형식: {\"lines\":[\"...\"]}\n` +
+          `- lines 길이: 정확히 25개\n` +
+          `- 각 라인은 1문장/짧은 구 형태, XML/마크다운 코드블록 금지\n` +
+          `- 톤: 링크드인에 올릴 수 있는 전문적/실무 공유 톤\n` +
+          `- 프로젝트 맥락: HWPX Editor for Vercel, AI 제안 API(/api/suggest, /api/suggest-batch), XML 텍스트 치환, 무결성 검사(mimetype/version.xml/content.hpf), Undo/Redo, 섹션 자동 선택, Diff 프리뷰\n` +
+          `- 구성: 제목, 날짜(${today}), 핵심성과, 기술포인트, 다음계획, 마지막 해시태그 라인\n` +
+          `- 과장 금지, 숫자/성과 중심으로 명확하게 작성`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "{}";
+  const parsed = parseJsonObject(content);
+  return normalizeLines(parsed.lines, today);
+}
+
+function findStartIndex(sectionNodes: Array<{ text: string }>): number {
+  const idx = sectionNodes.findIndex((node) => node.text.trim() === "오늘 작업 보고서");
+  return idx >= 0 ? idx : 0;
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      input: { type: "string" },
+      output: { type: "string" },
+      model: { type: "string" },
+    },
+    allowPositionals: false,
+  });
+
+  const dom = new JSDOM("");
+  (globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = dom.window.DOMParser;
+  (globalThis as unknown as { NodeFilter: typeof NodeFilter }).NodeFilter = dom.window.NodeFilter;
+
+  const inputPath = path.resolve(
+    process.cwd(),
+    values.input ?? "../examples/today-project-report.hwpx",
+  );
+  const outputPath = path.resolve(
+    process.cwd(),
+    values.output ?? "../examples/today-project-report-linkedin.hwpx",
+  );
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set.");
+  }
+
+  const baseURL = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
+  const model = values.model || process.env.OPENAI_MODEL || "gpt-4.1-mini";
+  const today = new Date().toISOString().slice(0, 10);
+
+  const input = await fs.readFile(inputPath);
+  const inputBuffer = input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength);
+  const beforeIssues = await validateHwpxArchive(inputBuffer);
+  if (beforeIssues.length) {
+    throw new Error(`입력 HWPX 무결성 경고: ${beforeIssues.join(" | ")}`);
+  }
+
+  const inspected = await inspectHwpx(inputBuffer);
+  const sectionNodes = inspected.textNodes.filter(
+    (node) => node.fileName === "Contents/section0.xml" && node.text.trim().length > 0,
+  );
+
+  const startIndex = findStartIndex(sectionNodes);
+  if (sectionNodes.length < startIndex + TARGET_LINE_COUNT) {
+    throw new Error(
+      `대상 노드 부족: start=${startIndex}, need=${TARGET_LINE_COUNT}, has=${sectionNodes.length}`,
+    );
+  }
+
+  const client = new OpenAI({ apiKey, baseURL });
+  const result = await generateLines(client, model, today);
+  const lines = result.lines;
+
+  const edits = lines.map((line, idx) => {
+    const node = sectionNodes[startIndex + idx];
+    return {
+      id: node.id,
+      fileName: node.fileName,
+      textIndex: node.textIndex,
+      oldText: node.text,
+      newText: line,
+    };
+  });
+
+  const outputBlob = await applyTextEdits(inputBuffer, edits);
+  const outputArray = new Uint8Array(await outputBlob.arrayBuffer());
+  const afterIssues = await validateHwpxArchive(outputArray.buffer);
+  if (afterIssues.length) {
+    throw new Error(`출력 HWPX 무결성 경고: ${afterIssues.join(" | ")}`);
+  }
+
+  await fs.writeFile(outputPath, outputArray);
+
+  console.log(`created: ${outputPath}`);
+  console.log(`line source: ${result.source}`);
+  console.log(`applied edits: ${edits.length}`);
+  console.log("preview lines:");
+  for (const line of lines.slice(0, 8)) {
+    console.log(`- ${line}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/generate-today-report.ts
+++ b/scripts/generate-today-report.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { JSDOM } from "jsdom";
+import { applyTextEdits, inspectHwpx, validateHwpxArchive } from "../src/lib/hwpx";
+
+async function main() {
+  const dom = new JSDOM("");
+  (globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = dom.window.DOMParser;
+  (globalThis as unknown as { NodeFilter: typeof NodeFilter }).NodeFilter = dom.window.NodeFilter;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const inputPath = path.resolve(process.cwd(), "../examples/input-sample.hwpx");
+  const outputPath = path.resolve(process.cwd(), "../examples/today-project-report.hwpx");
+
+  const reportLines = [
+    "오늘 작업 보고서",
+    `${today}`,
+    "프로젝트: HWPX Editor for Vercel",
+    "목표: HWPX 자동 편집 시스템의 실사용 가능성 검증",
+    "1. 구현 요약",
+    "- HWPX 업로드/노드 탐색/스타일 카탈로그 UI 구현",
+    "- 단건 AI 제안 및 일괄 제안 API(/api/suggest, /api/suggest-batch) 구현",
+    "- 수정 큐 적용 후 HWPX 재생성 기능 구현",
+    "2. 안정성 개선",
+    "- XML 전체 재직렬화 대신 텍스트 구간 치환 방식으로 변경",
+    "- HWPX 무결성 검사(mimetype, version.xml, content.hpf, XML 파싱) 추가",
+    "- 손상 리스크 경고를 UI에서 즉시 표시",
+    "3. UX 개선",
+    "- Undo/Redo(버튼 + 단축키) 구현",
+    "- 헤딩 기반 섹션 자동 선택 구현",
+    "- 원문/제안 Diff 미리보기 구현",
+    "4. 테스트 결과",
+    "- lint 통과",
+    "- test 통과(Undo/Redo, 섹션 선택, 무결성)",
+    "- build 통과",
+    "5. 다음 단계",
+    "- 실제 업무 HWPX 샘플 다건 회귀 테스트",
+    "- 스타일 규칙 사전(템플릿별) 보강",
+    "- 배포 환경에서 API 키 연결 후 문서 생성 자동화 확장",
+    "끝.",
+  ];
+
+  const input = await fs.readFile(inputPath);
+  const inputBuffer = input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength);
+  const beforeIssues = await validateHwpxArchive(inputBuffer);
+  if (beforeIssues.length) {
+    throw new Error(`입력 HWPX 무결성 경고: ${beforeIssues.join(" | ")}`);
+  }
+
+  const inspected = await inspectHwpx(inputBuffer);
+  const sectionNodes = inspected.textNodes.filter(
+    (node) => node.fileName === "Contents/section0.xml" && node.text.trim().length > 0,
+  );
+  if (sectionNodes.length < reportLines.length) {
+    throw new Error(
+      `보고서 라인(${reportLines.length})보다 대상 노드(${sectionNodes.length})가 적습니다.`,
+    );
+  }
+
+  const edits = reportLines.map((line, idx) => {
+    const node = sectionNodes[idx];
+    return {
+      id: node.id,
+      fileName: node.fileName,
+      textIndex: node.textIndex,
+      oldText: node.text,
+      newText: line,
+    };
+  });
+
+  const outputBlob = await applyTextEdits(inputBuffer, edits);
+  const outputArray = new Uint8Array(await outputBlob.arrayBuffer());
+  const afterIssues = await validateHwpxArchive(outputArray.buffer);
+  if (afterIssues.length) {
+    throw new Error(`출력 HWPX 무결성 경고: ${afterIssues.join(" | ")}`);
+  }
+
+  await fs.writeFile(outputPath, outputArray);
+  console.log(`created: ${outputPath}`);
+  console.log(`applied edits: ${edits.length}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/smoke-edit.ts
+++ b/scripts/smoke-edit.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { JSDOM } from "jsdom";
+import { applyTextEdits, inspectHwpx, validateHwpxArchive } from "../src/lib/hwpx";
+
+async function main() {
+  const dom = new JSDOM("");
+  (globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = dom.window.DOMParser;
+  (globalThis as unknown as { NodeFilter: typeof NodeFilter }).NodeFilter = dom.window.NodeFilter;
+
+  const inputPath = path.resolve(process.cwd(), "../examples/input-sample.hwpx");
+  const outputPath = path.resolve(process.cwd(), "../examples/edited-by-system.hwpx");
+
+  const input = await fs.readFile(inputPath);
+  const beforeIssues = await validateHwpxArchive(input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength));
+  if (beforeIssues.length) {
+    throw new Error(`input 무결성 경고: ${beforeIssues.join(" | ")}`);
+  }
+
+  const inspected = await inspectHwpx(input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength));
+  const target = inspected.textNodes.find((node) => node.text.trim().length > 0);
+  if (!target) {
+    throw new Error("수정 가능한 텍스트 노드를 찾지 못했습니다.");
+  }
+
+  const editedText = `${target.text} (AI 자동편집 검증 ${new Date().toISOString().slice(0, 10)})`;
+  const blob = await applyTextEdits(input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength), [
+    {
+      id: target.id,
+      fileName: target.fileName,
+      textIndex: target.textIndex,
+      oldText: target.text,
+      newText: editedText,
+    },
+  ]);
+
+  const outBuffer = new Uint8Array(await blob.arrayBuffer());
+  const afterIssues = await validateHwpxArchive(outBuffer.buffer);
+  if (afterIssues.length) {
+    throw new Error(`output 무결성 경고: ${afterIssues.join(" | ")}`);
+  }
+  await fs.writeFile(outputPath, outBuffer);
+  console.log(`created: ${outputPath}`);
+  console.log(`edited node: ${target.fileName} :: ${target.textIndex}`);
+  console.log(`before: ${target.text}`);
+  console.log(`after : ${editedText}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/api/analyze-document/route.ts
+++ b/src/app/api/analyze-document/route.ts
@@ -1,0 +1,85 @@
+import OpenAI from "openai";
+import { NextResponse } from "next/server";
+
+type SegmentInput = {
+  id: string;
+  text: string;
+  type: string;
+  level?: number;
+};
+
+type RequestBody = {
+  segments?: SegmentInput[];
+  model?: string;
+};
+
+export async function POST(request: Request) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  const baseURL = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
+  const defaultModel = process.env.OPENAI_MODEL || "gpt-4.1-mini";
+
+  if (!apiKey) {
+    return NextResponse.json({ error: "OPENAI_API_KEY가 설정되지 않았습니다." }, { status: 500 });
+  }
+
+  const body = (await request.json()) as RequestBody;
+  const segments = body.segments;
+
+  if (!segments || !segments.length) {
+    return NextResponse.json({ error: "segments가 비어있습니다." }, { status: 400 });
+  }
+
+  const model = body.model || defaultModel;
+  const client = new OpenAI({ apiKey, baseURL });
+
+  // Truncate each segment text to 200 chars, limit to 100 segments
+  const truncated = segments.slice(0, 100).map((s) => ({
+    id: s.id,
+    text: s.text.slice(0, 200),
+    type: s.type,
+    level: s.level,
+  }));
+
+  try {
+    const completion = await client.chat.completions.create({
+      model,
+      temperature: 0.3,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content:
+            '너는 한국어 문서 분석 AI다. JSON만 반환한다. 반드시 {"documentType":"...","suggestedPreset":"...","readabilityScore":0,"globalIssues":["..."],"inconsistentTerms":[{"variants":["..."],"suggestedTerm":"..."}]} 구조를 반환한다.',
+        },
+        {
+          role: "user",
+          content: `다음 문서의 세그먼트(최대 100개)를 분석하라.
+
+세그먼트(JSON):
+${JSON.stringify(truncated)}
+
+분석 항목:
+1. documentType: 문서 유형 (예: "기술제안서", "공문서", "연구보고서", "사업계획서", "일반 보고서" 등)
+2. suggestedPreset: 추천 프리셋 키 (technical_proposal, official_document, research_report, business_plan, custom 중 하나)
+3. readabilityScore: 가독성 점수 (1-100, 100이 최고)
+4. globalIssues: 문서 전체에서 발견되는 문제점 (예: "주어 생략이 빈번함", "수동태 과다 사용", "문장이 지나치게 길음", "경어체와 반말이 혼용됨" 등). 최대 5개.
+5. inconsistentTerms: 같은 개념에 다른 단어가 사용된 경우 (예: "시스템"과 "체계"가 혼용). variants에는 사용된 모든 표현, suggestedTerm에는 통일할 용어. 최대 5개.`,
+        },
+      ],
+    });
+
+    const text = completion.choices[0]?.message?.content || "{}";
+    const parsed = JSON.parse(text);
+
+    return NextResponse.json({
+      documentType: parsed.documentType || "일반 문서",
+      suggestedPreset: parsed.suggestedPreset || "custom",
+      readabilityScore: typeof parsed.readabilityScore === "number" ? parsed.readabilityScore : 50,
+      globalIssues: Array.isArray(parsed.globalIssues) ? parsed.globalIssues : [],
+      inconsistentTerms: Array.isArray(parsed.inconsistentTerms) ? parsed.inconsistentTerms : [],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "문서 분석 실패";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,412 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type {
+  ChatRequest,
+  DocumentContext,
+  DocumentContextSegment,
+} from "@/types/chat";
+
+const SYSTEM_PROMPT = `너는 한국어 문서 편집 전문 AI 어시스턴트다.
+사용자의 자연어 지시에 따라 문서를 분석하고 수정한다.
+
+규칙:
+1. 수정 전 반드시 read_document 도구로 현재 문서 내용을 확인하라.
+2. 대량 수정 시 사용자에게 변경 범위를 요약하고 확인을 구하라.
+3. 수정 후 변경 사항을 간결하게 보고하라.
+4. 한 번에 너무 많은 변경을 하지 말고 사용자와 단계별로 진행하라.
+5. 원문의 의미를 훼손하지 않도록 주의하라.
+6. 한국어로 응답하라.`;
+
+const TOOLS: Anthropic.Tool[] = [
+  {
+    name: "read_document",
+    description:
+      "현재 문서의 세그먼트(문단/제목) 목록을 조회합니다. startIndex/endIndex로 범위를 지정하거나, segmentIds로 특정 세그먼트만 조회할 수 있습니다.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        startIndex: { type: "number", description: "시작 인덱스 (생략시 0)" },
+        endIndex: { type: "number", description: "끝 인덱스 (생략시 전체)" },
+        segmentIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "특정 segmentId 목록 (지정 시 범위 무시)",
+        },
+      },
+    },
+  },
+  {
+    name: "read_segment",
+    description: "특정 segmentId의 텍스트를 조회합니다.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        segmentId: { type: "string", description: "조회할 세그먼트 ID" },
+      },
+      required: ["segmentId"],
+    },
+  },
+  {
+    name: "edit_segment",
+    description: "특정 세그먼트의 텍스트를 새 텍스트로 교체합니다.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        segmentId: { type: "string" },
+        newText: { type: "string" },
+      },
+      required: ["segmentId", "newText"],
+    },
+  },
+  {
+    name: "edit_segments",
+    description: "여러 세그먼트를 한 번에 수정합니다. 대량 편집에 사용합니다.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        edits: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              segmentId: { type: "string" },
+              newText: { type: "string" },
+            },
+            required: ["segmentId", "newText"],
+          },
+        },
+      },
+      required: ["edits"],
+    },
+  },
+  {
+    name: "search_replace",
+    description: "문서 전체에서 문자열을 찾아 치환합니다.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        search: { type: "string", description: "찾을 문자열" },
+        replace: { type: "string", description: "치환할 문자열" },
+        caseSensitive: {
+          type: "boolean",
+          description: "대소문자 구분 (기본 true)",
+        },
+      },
+      required: ["search", "replace"],
+    },
+  },
+  {
+    name: "analyze_style",
+    description: "문서의 전반적 스타일, 톤, 일관성을 분석합니다.",
+    input_schema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+];
+
+const READ_ONLY_TOOLS = new Set(["read_document", "read_segment", "analyze_style"]);
+
+/* ── Read-only tool execution (server-side) ── */
+
+function executeReadTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  docCtx: DocumentContext,
+): string {
+  const segments = docCtx.segments;
+
+  if (toolName === "read_document") {
+    const segmentIds = input.segmentIds as string[] | undefined;
+    if (segmentIds && segmentIds.length > 0) {
+      const found = segments.filter((s) => segmentIds.includes(s.segmentId));
+      return JSON.stringify(
+        found.map((s) => ({ id: s.segmentId, tag: s.tag, text: s.text })),
+      );
+    }
+    const start = (input.startIndex as number) || 0;
+    const end = (input.endIndex as number) || segments.length;
+    const slice = segments.slice(start, end);
+    return JSON.stringify(
+      slice.map((s, i) => ({
+        index: start + i,
+        id: s.segmentId,
+        tag: s.tag,
+        text: s.text,
+      })),
+    );
+  }
+
+  if (toolName === "read_segment") {
+    const segmentId = input.segmentId as string;
+    const seg = segments.find((s) => s.segmentId === segmentId);
+    if (!seg) return JSON.stringify({ error: `Segment not found: ${segmentId}` });
+    return JSON.stringify({ id: seg.segmentId, tag: seg.tag, text: seg.text });
+  }
+
+  if (toolName === "analyze_style") {
+    return analyzeDocumentStyle(segments);
+  }
+
+  return JSON.stringify({ error: `Unknown read tool: ${toolName}` });
+}
+
+function analyzeDocumentStyle(segments: DocumentContextSegment[]): string {
+  const headings = segments.filter((s) => s.tag === "h2" || s.tag === "h1" || s.tag === "h3");
+  const paragraphs = segments.filter((s) => s.tag === "p" || s.tag === "t");
+  const allText = segments.map((s) => s.text).join("\n");
+  const avgLen =
+    paragraphs.length > 0
+      ? Math.round(paragraphs.reduce((sum, s) => sum + s.text.length, 0) / paragraphs.length)
+      : 0;
+
+  const hasHonorific = /합니다|입니다|습니다/.test(allText);
+  const hasCasual = /한다\.|이다\.|된다\./.test(allText);
+  const hasMixed = hasHonorific && hasCasual;
+
+  return JSON.stringify({
+    totalSegments: segments.length,
+    headingCount: headings.length,
+    paragraphCount: paragraphs.length,
+    averageParagraphLength: avgLen,
+    toneAnalysis: hasMixed
+      ? "혼합체 (합쇼체 + 해라체 혼용)"
+      : hasHonorific
+        ? "합쇼체 (존댓말)"
+        : hasCasual
+          ? "해라체 (반말/서술체)"
+          : "기타/판단 불가",
+    totalCharacters: allText.length,
+  });
+}
+
+/* ── SSE helpers ── */
+
+function sendSSE(
+  controller: ReadableStreamDefaultController,
+  encoder: TextEncoder,
+  event: string,
+  data: unknown,
+) {
+  controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+}
+
+/* ── Route handler ── */
+
+export async function POST(request: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "ANTHROPIC_API_KEY is not set." }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let body: ChatRequest;
+  try {
+    body = (await request.json()) as ChatRequest;
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { messages, documentContext, approvedToolCall } = body;
+  const client = new Anthropic({ apiKey });
+  const model = process.env.ANTHROPIC_MODEL || "claude-sonnet-4-20250514";
+
+  // Convert ChatMessageAPI[] → Anthropic MessageParam[]
+  const anthropicMessages: Anthropic.MessageParam[] = [];
+  for (const msg of messages) {
+    if (typeof msg.content === "string") {
+      anthropicMessages.push({ role: msg.role, content: msg.content });
+    } else {
+      anthropicMessages.push({
+        role: msg.role,
+        content: msg.content as Anthropic.ContentBlockParam[],
+      });
+    }
+  }
+
+  // Continuation after tool approval/rejection: add tool_result
+  if (approvedToolCall) {
+    anthropicMessages.push({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: approvedToolCall.toolCallId,
+          content: approvedToolCall.result,
+        },
+      ],
+    });
+  }
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        await runAgentLoop(client, model, anthropicMessages, documentContext, controller, encoder);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        sendSSE(controller, encoder, "error", { type: "error", message });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+/* ── Agent loop: streaming + correct multi-tool handling ── */
+
+async function runAgentLoop(
+  client: Anthropic,
+  model: string,
+  messages: Anthropic.MessageParam[],
+  docCtx: DocumentContext,
+  controller: ReadableStreamDefaultController,
+  encoder: TextEncoder,
+) {
+  const MAX_ITERATIONS = 10;
+
+  for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+    // Use streaming API for incremental text delivery
+    const stream = client.messages.stream({
+      model,
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      tools: TOOLS,
+      messages,
+    });
+
+    // Accumulate streamed text for later message reconstruction
+    let accumulatedText = "";
+
+    stream.on("text", (textDelta) => {
+      accumulatedText += textDelta;
+      sendSSE(controller, encoder, "text_delta", {
+        type: "text_delta",
+        content: textDelta,
+      });
+    });
+
+    // Wait for the full response
+    const response = await stream.finalMessage();
+
+    // Collect all tool_use blocks from the response
+    const toolUseBlocks = response.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+    );
+
+    // No tool calls → just finish
+    if (toolUseBlocks.length === 0) {
+      sendSSE(controller, encoder, "done", {
+        type: "done",
+        usage: {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+        },
+      });
+      return;
+    }
+
+    // Check if any tool_use is a write tool
+    const hasWriteTool = toolUseBlocks.some((b) => !READ_ONLY_TOOLS.has(b.name));
+
+    if (hasWriteTool) {
+      // Mixed or write-only: send ALL tool calls, mark write ones as pending
+      // The FIRST write tool becomes the pending one, rest are ignored
+      // (Claude typically sends one write tool at a time per our system prompt)
+      for (const block of toolUseBlocks) {
+        const toolCall = {
+          id: block.id,
+          name: block.name,
+          input: block.input as Record<string, unknown>,
+        };
+
+        if (!READ_ONLY_TOOLS.has(block.name)) {
+          sendSSE(controller, encoder, "tool_pending", {
+            type: "tool_pending",
+            toolCall,
+          });
+        } else {
+          // Auto-execute accompanying read tools
+          const result = executeReadTool(block.name, toolCall.input, docCtx);
+          sendSSE(controller, encoder, "tool_call", { type: "tool_call", toolCall });
+          sendSSE(controller, encoder, "tool_result", {
+            type: "tool_result",
+            result: { toolCallId: block.id, name: block.name, result, isAutoExecuted: true },
+          });
+        }
+      }
+
+      // Push assistant content for context preservation, then stop
+      messages.push({
+        role: "assistant",
+        content: response.content as Anthropic.ContentBlockParam[],
+      });
+
+      sendSSE(controller, encoder, "done", {
+        type: "done",
+        waitingForApproval: true,
+        usage: {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+        },
+      });
+      return;
+    }
+
+    // All tool_use blocks are read-only → auto-execute ALL, then continue loop
+    // Step 1: Push the assistant's response as-is
+    messages.push({
+      role: "assistant",
+      content: response.content as Anthropic.ContentBlockParam[],
+    });
+
+    // Step 2: Build a single user message with ALL tool_results
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const block of toolUseBlocks) {
+      const toolCall = {
+        id: block.id,
+        name: block.name,
+        input: block.input as Record<string, unknown>,
+      };
+      sendSSE(controller, encoder, "tool_call", { type: "tool_call", toolCall });
+
+      const result = executeReadTool(block.name, toolCall.input, docCtx);
+      sendSSE(controller, encoder, "tool_result", {
+        type: "tool_result",
+        result: { toolCallId: block.id, name: block.name, result, isAutoExecuted: true },
+      });
+
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content: result,
+      });
+    }
+
+    // Step 3: Push ALL tool_results in a single user message
+    messages.push({
+      role: "user",
+      content: toolResults,
+    });
+
+    // Continue the agent loop → Claude will process results and respond
+  }
+
+  sendSSE(controller, encoder, "error", {
+    type: "error",
+    message: "Maximum agent iterations reached.",
+  });
+}

--- a/src/app/api/suggest-batch/route.ts
+++ b/src/app/api/suggest-batch/route.ts
@@ -5,6 +5,8 @@ type BatchItem = {
   id: string;
   text: string;
   styleHints?: Record<string, string>;
+  prevText?: string;
+  nextText?: string;
 };
 
 type RequestBody = {
@@ -65,7 +67,7 @@ export async function POST(request: Request) {
           content:
             `수정 지시:\n${instruction}\n\n` +
             `항목(JSON):\n${JSON.stringify(items)}\n\n` +
-            "요구사항: 각 항목의 의미를 보존하고 더 읽기 좋게 다듬어라. 원문 길이와 문장 수는 유사하게 유지하라.",
+            "요구사항: 각 항목의 text만 수정하라. prevText/nextText는 맥락 참고용이며 수정 대상이 아니다. 각 항목의 의미를 보존하고 더 읽기 좋게 다듬어라. 원문 길이와 문장 수는 유사하게 유지하라.",
         },
       ],
     });

--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -5,6 +5,8 @@ type RequestBody = {
   text?: string;
   instruction?: string;
   styleHints?: Record<string, string>;
+  prevText?: string;
+  nextText?: string;
   model?: string;
 };
 
@@ -46,10 +48,12 @@ export async function POST(request: Request) {
         {
           role: "user",
           content:
+            (body.prevText ? `앞 문단:\n${body.prevText}\n\n` : "") +
             `원문:\n${text}\n\n` +
+            (body.nextText ? `뒤 문단:\n${body.nextText}\n\n` : "") +
             `수정 지시:\n${instruction}\n\n` +
             `스타일 힌트(JSON):\n${styleContext}\n\n` +
-            "요구사항: 문장 수와 길이는 원문과 유사하게 유지하고, 핵심 정보 누락 없이 더 읽기 좋게 고쳐라.",
+            "요구사항: 원문만 수정하라. 앞/뒤 문단은 맥락 참고용이다. 문장 수와 길이는 원문과 유사하게 유지하고, 핵심 정보 누락 없이 더 읽기 좋게 고쳐라.",
         },
       ],
     });

--- a/src/app/api/verify/route.ts
+++ b/src/app/api/verify/route.ts
@@ -1,0 +1,75 @@
+import OpenAI from "openai";
+import { NextResponse } from "next/server";
+
+type RequestBody = {
+  originalText?: string;
+  modifiedText?: string;
+  instruction?: string;
+  model?: string;
+};
+
+export async function POST(request: Request) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  const baseURL = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
+  const defaultModel = process.env.OPENAI_MODEL || "gpt-4.1-mini";
+
+  if (!apiKey) {
+    return NextResponse.json({ error: "OPENAI_API_KEY가 설정되지 않았습니다." }, { status: 500 });
+  }
+
+  const body = (await request.json()) as RequestBody;
+  const { originalText, modifiedText, instruction } = body;
+
+  if (!originalText || !modifiedText) {
+    return NextResponse.json({ error: "originalText와 modifiedText가 필요합니다." }, { status: 400 });
+  }
+
+  const model = body.model || defaultModel;
+  const client = new OpenAI({ apiKey, baseURL });
+
+  try {
+    const completion = await client.chat.completions.create({
+      model,
+      temperature: 0.1,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content:
+            '너는 문서 편집 검증 AI다. JSON만 반환한다. 반드시 {"passed":true/false,"issues":["..."]} 구조를 반환한다.',
+        },
+        {
+          role: "user",
+          content: `다음 수정이 올바른지 검증하라.
+
+원문:
+${originalText}
+
+수정문:
+${modifiedText}
+
+수정 지시:
+${instruction || "(없음)"}
+
+검증 항목:
+1. 정보 손실: 원문의 핵심 정보(날짜, 수치, 고유명사, 사실관계)가 누락되었는가?
+2. 톤 일관성: 수정 전후의 문체/격식이 일관되는가?
+3. 의미 변질: 원문의 핵심 의미가 왜곡되었는가?
+
+이슈가 없으면 passed: true, issues: []. 이슈가 있으면 passed: false와 구체적 이슈 목록을 반환하라.`,
+        },
+      ],
+    });
+
+    const text = completion.choices[0]?.message?.content || "{}";
+    const parsed = JSON.parse(text);
+
+    return NextResponse.json({
+      passed: typeof parsed.passed === "boolean" ? parsed.passed : true,
+      issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "검증 실패";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,81 +27,48 @@ button {
   font: inherit;
 }
 
+/* ── HWP flat button (global) ── */
 .btn {
-  border: 1px solid #bdd2e7;
-  background: #ffffff;
-  border-radius: 10px;
-  padding: 9px 12px;
-  font-size: 0.9rem;
+  border: 1px solid #b4b4b4;
+  background: #f0f0f0;
+  border-radius: 2px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
   cursor: pointer;
+  white-space: nowrap;
+  color: #1a1a1a;
+}
+
+.btn:hover:not(:disabled) {
+  background: #d8e8f8;
+  border-color: #90b4d4;
+}
+
+.btn:active:not(:disabled) {
+  background: #c0d8f0;
+  border-color: #6090c0;
 }
 
 .btn.primary {
   border-color: #1d4f80;
-  background: linear-gradient(120deg, #1d4f80, #0f766e);
+  background: #1d4f80;
   color: #fff;
 }
 
+.btn.primary:hover:not(:disabled) {
+  background: #2a6da8;
+}
+
 .btn:disabled {
-  opacity: 0.55;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-.download-wrap {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.download-link {
-  font-size: 0.85rem;
-  color: #0369a1;
-  font-weight: 600;
-}
-
-.editor-toolbar {
-  border: 1px solid #d8e4f1;
-  border-radius: 12px;
-  background: #fff;
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  padding: 8px;
-}
-
-.toolbar-group {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.toolbar-btn {
-  border: 1px solid #d0dce9;
-  background: #fbfdff;
-  border-radius: 8px;
-  padding: 7px 10px;
-  font-size: 0.84rem;
-  cursor: pointer;
-}
-
-.toolbar-btn.active {
-  border-color: #3f7aad;
-  background: #ecf4ff;
-}
-
-.toolbar-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
+/* ── Document editor inside A4 paper ── */
 .document-editor-wrap {
-  border: 1px solid #d7e3f0;
-  border-radius: 14px;
   background: #fff;
-  min-height: 640px;
   height: 100%;
-  overflow: auto;
 }
 
 .document-editor {
@@ -109,44 +76,62 @@ button {
 }
 
 .document-editor .ProseMirror {
-  min-height: 620px;
-  padding: 22px 28px;
+  /* HWP-like A4 margins: ~25mm each side inside 794px paper */
+  padding: 60px 80px;
+  min-height: 1060px;
   outline: none;
-  font-size: 1rem;
-  line-height: 1.7;
+  font-family: '바탕', 'Batang', 'serif';
+  font-size: 10pt;
+  line-height: 1.6;
   letter-spacing: 0;
   word-break: keep-all;
+  color: #111;
 }
 
 .document-editor .ProseMirror p {
-  margin: 0 0 10px;
+  margin: 0 0 4px;
   white-space: pre-wrap;
 }
 
-.document-editor .ProseMirror h1,
-.document-editor .ProseMirror h2,
-.document-editor .ProseMirror h3 {
-  margin: 18px 0 10px;
+.document-editor .ProseMirror h1 {
+  font-size: 16pt;
+  font-weight: bold;
+  margin: 20px 0 8px;
   line-height: 1.35;
-  white-space: pre-wrap;
+}
+
+.document-editor .ProseMirror h2 {
+  font-size: 13pt;
+  font-weight: bold;
+  margin: 16px 0 6px;
+  line-height: 1.35;
+}
+
+.document-editor .ProseMirror h3 {
+  font-size: 11pt;
+  font-weight: bold;
+  margin: 14px 0 4px;
+  line-height: 1.35;
 }
 
 .document-editor .ProseMirror table {
   border-collapse: collapse;
   table-layout: fixed;
   width: 100%;
-  margin: 10px 0 14px;
+  margin: 10px 0 12px;
 }
 
 .document-editor .ProseMirror td,
 .document-editor .ProseMirror th {
-  border: 1px solid #c9d9ea;
-  padding: 6px 8px;
+  border: 1px solid #888;
+  padding: 4px 6px;
   vertical-align: top;
+  font-size: 9pt;
+  line-height: 1.5;
 }
 
 .document-editor .ProseMirror .selectedCell {
-  background: #e8f2ff;
+  background: #d6eaff;
 }
 
 .document-editor .ProseMirror hr {
@@ -155,57 +140,22 @@ button {
   margin: 14px 0;
 }
 
-.sidebar {
-  border: 1px solid #d8e4f1;
-  border-radius: 14px;
-  background: #fff;
-  display: flex;
-  flex-direction: column;
-  min-height: 640px;
-}
-
-.sidebar-tabs {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.sidebar-tab {
-  border: none;
-  background: #fff;
-  padding: 10px 8px;
-  font-size: 0.84rem;
-  cursor: pointer;
-}
-
-.sidebar-tab.active {
-  background: #f0f7ff;
-  font-weight: 700;
-}
-
-.sidebar-content {
-  flex: 1;
-  min-height: 0;
-  overflow: auto;
-  padding: 12px;
-}
-
+/* ── Sidebar panel content: shared global classes ── */
 .sidebar-empty {
   color: #64748b;
-  font-size: 0.86rem;
+  font-size: 12px;
+  padding: 4px 0;
 }
 
+/* ── Outline list (tree-view style) ── */
 .outline-list {
   list-style: none;
   display: grid;
-  gap: 8px;
+  gap: 1px;
 }
 
 .outline-list li {
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  padding: 4px;
-  font-size: 0.88rem;
+  padding: 0;
 }
 
 .outline-item-btn {
@@ -213,17 +163,26 @@ button {
   border: none;
   background: transparent;
   text-align: left;
-  padding: 6px;
-  border-radius: 6px;
+  padding: 3px 6px;
+  border-radius: 0;
   cursor: pointer;
+  font-family: '바탕', 'Batang', serif;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #1a1a1a;
+}
+
+.outline-item-btn:hover {
+  background: #e8f0fa;
 }
 
 .outline-item-btn.active {
-  background: #eff6ff;
+  background: #d0e4f8;
   color: #0f4f8a;
   font-weight: 700;
 }
 
+/* ── AI panel ── */
 .ai-panel {
   display: grid;
   gap: 8px;
@@ -231,128 +190,172 @@ button {
 
 .sidebar-label {
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: 11px;
   color: #334155;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
 }
 
 .sidebar-box {
-  border: 1px solid #dbe6f1;
-  border-radius: 8px;
-  background: #f8fbff;
-  padding: 9px;
-  min-height: 56px;
-  font-size: 0.86rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 2px;
+  background: #fff;
+  padding: 6px 8px;
+  min-height: 36px;
+  font-size: 12px;
   line-height: 1.5;
   white-space: pre-wrap;
+  color: #333;
 }
 
 .sidebar-textarea {
-  border: 1px solid #dbe6f1;
-  border-radius: 8px;
-  min-height: 90px;
+  border: 1px solid #d0d0d0;
+  border-radius: 2px;
+  min-height: 60px;
   resize: vertical;
-  padding: 8px;
-  font: inherit;
-  font-size: 0.88rem;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
 }
 
 .sidebar-actions {
   display: flex;
-  gap: 6px;
+  gap: 4px;
+  flex-wrap: wrap;
 }
 
+/* ── Batch diff ── */
 .batch-diff-list {
   list-style: none;
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .batch-diff-item {
-  border: 1px solid #dbe6f1;
-  border-radius: 8px;
-  background: #f8fbff;
-  padding: 8px;
-  display: grid;
-  gap: 6px;
-}
-
-.batch-diff-item strong {
-  font-size: 0.78rem;
-  color: #475569;
-}
-
-.batch-diff-grid {
-  display: grid;
-  gap: 6px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.batch-diff-col {
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  background: #ffffff;
+  border: 1px solid #d0d0d0;
+  border-radius: 2px;
+  background: #fff;
   padding: 6px;
   display: grid;
   gap: 4px;
 }
 
+.batch-diff-item strong {
+  font-size: 10px;
+  color: #475569;
+}
+
+.batch-diff-grid {
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.batch-diff-col {
+  border: 1px solid #e2e8f0;
+  border-radius: 2px;
+  background: #fafafa;
+  padding: 4px 6px;
+  display: grid;
+  gap: 2px;
+}
+
 .batch-diff-col small {
   color: #64748b;
-  font-size: 0.72rem;
+  font-size: 10px;
 }
 
 .batch-diff-col p {
   white-space: pre-wrap;
-  font-size: 0.78rem;
-  line-height: 1.45;
+  font-size: 11px;
+  line-height: 1.4;
 }
 
+/* ── Batch decision buttons (accept/reject) ── */
+.batch-decision-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 20px;
+  border: 1px solid #c0c0c0;
+  border-radius: 2px;
+  background: #f4f4f4;
+  font-size: 12px;
+  cursor: pointer;
+  color: #666;
+  padding: 0;
+  line-height: 1;
+}
+
+.batch-decision-btn:hover {
+  background: #e0e0e0;
+}
+
+.batch-decision-btn[data-state="accepted"] {
+  background: #dcfce7;
+  border-color: #86efac;
+  color: #166534;
+}
+
+.batch-decision-btn[data-state="rejected"] {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #991b1b;
+}
+
+/* ── History list ── */
 .history-list {
   list-style: none;
-  display: grid;
-  gap: 10px;
-}
-
-.history-list li {
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  padding: 8px;
   display: grid;
   gap: 4px;
 }
 
+.history-list li {
+  border: 1px solid #d0d0d0;
+  border-radius: 2px;
+  padding: 6px 8px;
+  display: grid;
+  gap: 2px;
+  background: #fff;
+}
+
 .history-list strong {
-  font-size: 0.88rem;
+  font-size: 12px;
 }
 
 .history-list small,
 .history-list span {
   color: #64748b;
-  font-size: 0.8rem;
+  font-size: 11px;
 }
 
+/* ── Status bar (flat HWP style) ── */
 .status-bar {
-  border: 1px solid #d8e4f1;
-  border-radius: 10px;
-  background: #fff;
-  padding: 8px 10px;
+  border-top: 1px solid #c0c0c0;
+  background: #e8e8e8;
+  padding: 3px 10px;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  font-size: 0.84rem;
-  color: #475569;
+  font-size: 11px;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
+  color: #333;
+  flex-shrink: 0;
+  height: 22px;
+  align-items: center;
 }
 
 .status-bar strong {
   color: #0f172a;
 }
 
+/* ── Slash command menu ── */
 .slash-command-menu {
   width: 270px;
   background: #fff;
-  border: 1px solid #d8e4f1;
-  border-radius: 10px;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  border: 1px solid #c0c0c0;
+  border-radius: 2px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   overflow: hidden;
 }
 
@@ -362,26 +365,321 @@ button {
   background: #fff;
   text-align: left;
   cursor: pointer;
-  padding: 9px 11px;
+  padding: 6px 10px;
   display: grid;
   gap: 2px;
 }
 
 .slash-command-item.active {
-  background: #eff6ff;
+  background: #d0e4f8;
 }
 
 .slash-command-item strong {
-  font-size: 0.86rem;
+  font-size: 12px;
 }
 
 .slash-command-item small {
-  font-size: 0.76rem;
+  font-size: 11px;
   color: #64748b;
 }
 
 .slash-command-empty {
   padding: 10px;
   color: #64748b;
-  font-size: 0.84rem;
+  font-size: 12px;
+}
+
+/* ── 에디터 내 세그먼트 Diff 하이라이트 ── */
+.document-editor .ProseMirror .diff-pending {
+  border-left: 3px solid #22c55e;
+  background: #fefce8;
+  padding-left: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.document-editor .ProseMirror .diff-pending:hover {
+  background: #fef9c3;
+}
+
+.document-editor .ProseMirror .diff-accepted {
+  border-left: 3px solid #16a34a;
+  background: #dcfce7;
+  padding-left: 6px;
+}
+
+.document-editor .ProseMirror .diff-rejected {
+  border-left: 3px solid #d1d5db;
+  background: #f9fafb;
+  padding-left: 6px;
+  opacity: 0.6;
+}
+
+/* ── 사이드바 인라인 Diff 텍스트 ── */
+.diff-text-removed {
+  background: #fee2e2;
+  color: #991b1b;
+  text-decoration: line-through;
+}
+.diff-text-added {
+  background: #dcfce7;
+  color: #166534;
+}
+
+/* ── ChatPanel 스타일 ── */
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.chat-messages {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
+.chat-msg {
+  display: flex;
+  flex-direction: column;
+  max-width: 90%;
+}
+
+.chat-msg-user {
+  align-self: flex-end;
+}
+
+.chat-msg-assistant {
+  align-self: flex-start;
+}
+
+.chat-bubble {
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.chat-bubble-user {
+  background: #2563eb;
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-bubble-assistant {
+  background: #f3f4f6;
+  color: #1f2937;
+  border-bottom-left-radius: 4px;
+}
+
+.chat-bubble-text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.chat-typing {
+  animation: pulse 1.2s infinite;
+  color: #9ca3af;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.chat-tool-calls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.chat-tool-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: #e5e7eb;
+  color: #4b5563;
+}
+
+.chat-tool-badge.auto {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.chat-tool-badge.manual {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+/* Pending tool approval */
+.chat-pending-tool {
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+  border-radius: 8px;
+  padding: 10px;
+  margin-top: 4px;
+}
+
+.chat-pending-tool-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.chat-tool-name {
+  font-size: 12px;
+  color: #6b7280;
+  font-family: monospace;
+}
+
+.chat-tool-summary {
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 6px 0;
+}
+
+.chat-tool-diffs {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fff;
+  margin-bottom: 8px;
+}
+
+.chat-diff-item {
+  padding: 6px 8px;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.chat-diff-item:last-child {
+  border-bottom: none;
+}
+
+.chat-pending-tool-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* Quick command chips */
+.chat-quick-commands {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 12px 8px;
+}
+
+.chat-quick-chip {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 14px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.chat-quick-chip:hover {
+  background: #e5e7eb;
+  border-color: #d1d5db;
+}
+
+.chat-quick-chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Input area */
+.chat-input-area {
+  border-top: 1px solid #e5e7eb;
+  padding: 8px 12px;
+  background: #fff;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.chat-textarea {
+  flex: 1;
+  resize: none;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.4;
+  outline: none;
+  min-height: 36px;
+  max-height: 120px;
+  font-family: inherit;
+}
+
+.chat-textarea:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+}
+
+.chat-textarea:disabled {
+  background: #f9fafb;
+  color: #9ca3af;
+}
+
+.chat-send-btn {
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.chat-send-btn:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.chat-send-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-clear-btn {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 4px;
+  border: none;
+  background: none;
+  font-size: 11px;
+  color: #9ca3af;
+  cursor: pointer;
+  text-align: center;
+}
+
+.chat-clear-btn:hover:not(:disabled) {
+  color: #6b7280;
 }

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,174 +1,162 @@
+/* HWP-like full-window application shell */
 .page {
-  min-height: 100vh;
-  padding: 24px;
-  background:
-    radial-gradient(circle at 0% 0%, #e8f4ff 0%, transparent 30%),
-    radial-gradient(circle at 100% 0%, #fef3e4 0%, transparent 25%),
-    #f7fafc;
-  color: #0f172a;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  height: 100vh;
+  overflow: hidden;
+  background: #d1d1d1;
+  color: #1a1a1a;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
 }
 
-.header {
-  border: 1px solid #d9e5f2;
-  border-radius: 14px;
-  background: #ffffffde;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 18px;
-}
-
-.header h1 {
-  font-size: clamp(1.4rem, 2.7vw, 2rem);
-  letter-spacing: -0.02em;
-}
-
-.header p {
-  color: #334155;
-  margin-top: 6px;
-  font-size: 0.95rem;
-}
-
-.headerActions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
+/* ── Main workspace: canvas + sidebar ── */
 .main {
   flex: 1;
   min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 340px;
-  gap: 12px;
+  display: flex;
+  overflow: hidden;
 }
 
+/* Editor canvas (scrollable) */
 .editorArea {
-  min-height: 0;
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: #d1d1d1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 0;
 }
 
+/* Ruler + paper wrapper centered */
+.editorCenter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 18px 0 32px;
+}
+
+/* ── Warning banners ── */
 .warning,
 .warningSoft {
-  border-radius: 12px;
-  padding: 10px 12px;
+  border-radius: 0;
+  padding: 6px 14px;
+  font-size: 12px;
+  flex-shrink: 0;
 }
 
 .warning {
-  border: 1px solid #f4b5a6;
+  border-bottom: 1px solid #f4b5a6;
   background: #fff1ed;
   color: #7c2d12;
 }
 
 .warningSoft {
-  border: 1px solid #f5d899;
+  border-bottom: 1px solid #f5d899;
   background: #fffbeb;
   color: #7c4a03;
 }
 
 .warning strong,
 .warningSoft strong {
-  display: block;
-  margin-bottom: 4px;
+  display: inline;
+  margin-right: 6px;
 }
 
 .warning p,
 .warningSoft p {
-  font-size: 0.86rem;
+  display: inline;
   line-height: 1.4;
 }
 
-/* View mode tab switcher */
+/* ── View mode tab switcher (편집/미리보기) ── */
 .viewTabs {
   display: flex;
-  gap: 4px;
-  margin-bottom: 8px;
+  gap: 0;
+  flex-shrink: 0;
+  background: #e8e8e8;
+  border-bottom: 1px solid #b8b8b8;
+  width: 794px;
+  margin-bottom: 0;
 }
 
 .viewTabBtn {
-  padding: 5px 14px;
-  border: 1px solid #d1dde8;
-  border-radius: 8px;
-  background: #f7fafc;
-  color: #475569;
-  font-size: 0.85rem;
+  padding: 5px 18px;
+  border: none;
+  border-right: 1px solid #c0c0c0;
+  background: #e8e8e8;
+  color: #444;
+  font-size: 12px;
+  font-family: inherit;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition: background 0.1s;
 }
 
 .viewTabBtn:hover:not(:disabled) {
-  background: #e8f2fa;
-  color: #1e40af;
+  background: #d8e8f8;
 }
 
 .viewTabBtn:disabled {
-  opacity: 0.4;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
 .viewTabBtnActive {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #fff;
-  font-weight: 600;
+  background: #ffffff !important;
+  color: #1a4880;
+  font-weight: 700;
+  border-bottom: 2px solid #1a4880;
 }
 
-.viewTabBtnActive:hover:not(:disabled) {
-  background: #1d4ed8;
-  color: #fff;
-}
-
-/* Java HTML preview pane */
+/* ── Java HTML preview pane inside the paper ── */
 .previewPane {
+  width: 794px;
+  min-height: 1123px;
   background: #fff;
-  border: 1px solid #d9e5f2;
-  border-radius: 12px;
-  padding: 32px 40px;
-  line-height: 1.75;
-  color: #0f172a;
-  font-size: 0.95rem;
-  overflow-y: auto;
-  max-height: 75vh;
+  padding: 60px 80px;
+  line-height: 1.6;
+  color: #111;
+  font-size: 10pt;
+  font-family: '바탕', 'Batang', serif;
   cursor: default;
 }
 
 .previewPane [data-segment-id] {
   cursor: pointer;
-  border-radius: 3px;
-  transition: background 0.12s;
+  border-radius: 2px;
+  transition: background 0.1s;
 }
 
 .previewPane [data-segment-id]:hover {
-  background: #eff6ff;
-  outline: 1px solid #93c5fd;
+  background: #e8f2ff;
+  outline: 1px solid #90c0f0;
 }
 
 .previewPane table {
   border-collapse: collapse;
   width: 100%;
-  margin: 16px 0;
+  margin: 10px 0;
 }
 
 .previewPane td,
 .previewPane th {
-  border: 1px solid #d1dde8;
-  padding: 6px 10px;
+  border: 1px solid #888;
+  padding: 4px 6px;
   vertical-align: top;
+  font-size: 9pt;
 }
 
 .previewPane h2,
 .previewPane h3 {
-  font-weight: 700;
-  margin: 20px 0 8px;
+  font-weight: bold;
+  margin: 14px 0 6px;
 }
 
-@media (max-width: 1180px) {
-  .main {
-    grid-template-columns: minmax(0, 1fr);
+@media (max-width: 920px) {
+  .viewTabs,
+  .previewPane {
+    width: 100%;
   }
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,36 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import type { Editor } from "@tiptap/core";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Editor, JSONContent } from "@tiptap/core";
 import { Fragment, type Node as PMNode } from "@tiptap/pm/model";
+import { useCallback } from "react";
 import { DocumentEditor } from "@/components/editor/DocumentEditor";
 import { EditorToolbar } from "@/components/editor/EditorToolbar";
-import { FileUpload } from "@/components/common/FileUpload";
-import { DownloadButton } from "@/components/common/DownloadButton";
+import { EditorLayout } from "@/components/editor/EditorLayout";
+import { EditorRuler } from "@/components/editor/EditorRuler";
 import { StatusBar } from "@/components/common/StatusBar";
 import { Sidebar } from "@/components/sidebar/Sidebar";
 import { DocumentOutline } from "@/components/sidebar/DocumentOutline";
 import { AiSuggestionPanel } from "@/components/sidebar/AiSuggestionPanel";
+import { ChatPanel } from "@/components/sidebar/ChatPanel";
 import { EditHistoryPanel } from "@/components/sidebar/EditHistoryPanel";
+import { DocumentAnalysisPanel } from "@/components/sidebar/DocumentAnalysisPanel";
+import { streamChat } from "@/lib/chat/chat-stream";
+import type { ChatMessageAPI, DocumentContext, EditPreview, ToolCallInfo } from "@/types/chat";
 import { buildBatchApplyPlan, collectSectionBatchItems } from "@/lib/editor/batch-ai";
 import { buildDirtySummary, buildOutlineFromDoc } from "@/lib/editor/document-store";
 import { parseHwpxToProseMirror } from "@/lib/editor/hwpx-to-prosemirror";
+import { parseDocxToProseMirror } from "@/lib/editor/docx-to-prosemirror";
+import { parsePptxToProseMirror } from "@/lib/editor/pptx-to-prosemirror";
 import { applyProseMirrorDocToHwpx, collectDocumentEdits } from "@/lib/editor/prosemirror-to-hwpx";
+import { exportToPdf } from "@/lib/editor/export-pdf";
+import { exportToDocx } from "@/lib/editor/export-docx";
+import { triggerDiffHighlightUpdate } from "@/lib/editor/diff-highlight-extension";
+import type { DiffHighlightSuggestion } from "@/lib/editor/diff-highlight-extension";
+import { INSTRUCTION_PRESETS } from "@/lib/editor/ai-presets";
+import type { PresetKey } from "@/lib/editor/ai-presets";
 import { useDocumentStore } from "@/store/document-store";
-import type { RenderElementInfo } from "@/store/document-store";
+import type { RenderElementInfo, SidebarTab } from "@/store/document-store";
 import styles from "./page.module.css";
 
 function replaceSegmentText(editor: Editor, segmentId: string, nextText: string): boolean {
@@ -121,6 +134,62 @@ function applyBatchSegmentTexts(editor: Editor, updates: SegmentTextUpdate[]): n
   return ranges.length;
 }
 
+function extractNodeText(node: JSONContent): string {
+  if (node.type === "text") {
+    return node.text || "";
+  }
+  if (node.type === "hardBreak") {
+    return "\n";
+  }
+  if (!node.content?.length) {
+    return "";
+  }
+  return node.content.map((child) => extractNodeText(child)).join("");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function applySearchReplace(
+  text: string,
+  search: string,
+  replace: string,
+  caseSensitive: boolean,
+): { nextText: string; replacements: number } {
+  if (!search) {
+    return { nextText: text, replacements: 0 };
+  }
+
+  if (caseSensitive) {
+    let index = 0;
+    let replacements = 0;
+    while (true) {
+      const found = text.indexOf(search, index);
+      if (found === -1) {
+        break;
+      }
+      replacements += 1;
+      index = found + search.length;
+    }
+    if (!replacements) {
+      return { nextText: text, replacements: 0 };
+    }
+    return {
+      nextText: text.split(search).join(replace),
+      replacements,
+    };
+  }
+
+  const re = new RegExp(escapeRegExp(search), "gi");
+  let replacements = 0;
+  const nextText = text.replace(re, () => {
+    replacements += 1;
+    return replace;
+  });
+  return { nextText, replacements };
+}
+
 type JavaRenderPayload = {
   html?: string;
   elementMap?: Record<string, RenderElementInfo>;
@@ -156,6 +225,26 @@ export default function Home() {
     renderHtml,
     renderElementMap,
 
+    // Phase 2-1: Accept/Reject
+    batchDecisions,
+    // Phase 2-3: Presets
+    selectedPreset,
+    // Phase 2-4: Document Intelligence
+    documentAnalysis,
+    analysisLoading,
+    // Phase 2-5: Terminology
+    terminologyDict,
+    // Phase 2-6: Verification
+    verificationResult,
+    verificationLoading,
+    // Batch mode
+    batchMode,
+
+    // Chat agent
+    chatMessages,
+    chatBusy,
+    pendingToolCall,
+
     setLoadedDocument,
     setEditorDoc,
     setOutline,
@@ -174,6 +263,33 @@ export default function Home() {
     setDownload,
     setRenderResult,
     pushHistory,
+
+    // Phase 2-1
+    setBatchDecision,
+    clearBatchDecisions,
+    // Phase 2-3
+    setSelectedPreset,
+    // Phase 2-4
+    setDocumentAnalysis,
+    setAnalysisLoading,
+    // Phase 2-5
+    updateTerminologyEntry,
+    removeTerminologyEntry,
+    // Phase 2-6
+    setVerificationResult,
+    setVerificationLoading,
+    // Batch mode
+    setBatchMode,
+
+    // Chat agent
+    addChatMessage,
+    updateLastAssistantMessage,
+    finalizeLastAssistantMessage,
+    setChatBusy,
+    setPendingToolCall,
+    clearChat,
+    appendToolCallToLastMessage,
+    appendToolResultToLastMessage,
   } = useDocumentStore();
 
   const downloadUrl = useMemo(() => {
@@ -185,8 +301,8 @@ export default function Home() {
 
   const dirtySummary = useMemo(() => buildDirtySummary(editsPreview), [editsPreview]);
   const batchItems = useMemo(
-    () => collectSectionBatchItems(editorDoc, selection.selectedSegmentId),
-    [editorDoc, selection.selectedSegmentId],
+    () => collectSectionBatchItems(editorDoc, batchMode === "document" ? null : selection.selectedSegmentId),
+    [editorDoc, selection.selectedSegmentId, batchMode],
   );
   const batchPlan = useMemo(
     () => buildBatchApplyPlan(batchItems, batchSuggestions),
@@ -217,30 +333,67 @@ export default function Home() {
     };
   }, [downloadUrl]);
 
+  /* ── Diff highlight sync: React → Editor ── */
+  useEffect(() => {
+    if (!editor) return;
+    const suggestions: DiffHighlightSuggestion[] = batchPlan
+      .filter((item) => item.changed)
+      .map((item) => ({
+        segmentId: item.id,
+        originalText: item.originalText,
+        suggestion: item.suggestion,
+        decision: batchDecisions[item.id],
+      }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor.storage as any).diffHighlight.suggestions = suggestions;
+    triggerDiffHighlightUpdate(editor);
+  }, [editor, batchPlan, batchDecisions]);
+
+  /* ── Sidebar tab toggle (from toolbar buttons) ── */
+  const handleSetSidebarTab = (tab: SidebarTab) => {
+    if (!sidebarCollapsed && activeSidebarTab === tab) {
+      toggleSidebar(); // same tab click → collapse
+    } else {
+      if (sidebarCollapsed) toggleSidebar();
+      setActiveSidebarTab(tab);
+    }
+  };
+
+  /* ── File I/O ── */
   const onPickFile = async (file: File) => {
     setBusy(true);
     setViewMode("editor");
-    setStatus("HWPX를 분석하고 WYSIWYG 문서로 변환 중입니다...");
+    const ext = file.name.toLowerCase().split(".").pop() || "";
+    const formatLabel = ext === "docx" ? "DOCX" : ext === "pptx" ? "PPTX" : "HWPX";
+    const isHwpx = ext === "hwpx";
+    setStatus(`${formatLabel}를 분석하고 변환 중입니다...`);
     try {
       const buffer = await file.arrayBuffer();
+      let parsePromise;
+      if (ext === "docx") parsePromise = parseDocxToProseMirror(buffer);
+      else if (ext === "pptx") parsePromise = parsePptxToProseMirror(buffer);
+      else parsePromise = parseHwpxToProseMirror(buffer);
+
       const [parsed] = await Promise.all([
-        parseHwpxToProseMirror(buffer),
-        // Fire Java rendering request concurrently; ignore errors (server may not be running)
-        (async () => {
-          try {
-            const fd = new FormData();
-            fd.append("file", file);
-            const resp = await fetch("/api/hwpx-render", { method: "POST", body: fd });
-            if (resp.ok) {
-              const payload = (await resp.json()) as JavaRenderPayload;
-              if (payload.html && payload.elementMap) {
-                setRenderResult(payload.html, payload.elementMap);
+        parsePromise,
+        // Fire Java rendering request concurrently (HWPX only)
+        !isHwpx
+          ? Promise.resolve()
+          : (async () => {
+              try {
+                const fd = new FormData();
+                fd.append("file", file);
+                const resp = await fetch("/api/hwpx-render", { method: "POST", body: fd });
+                if (resp.ok) {
+                  const payload = (await resp.json()) as JavaRenderPayload;
+                  if (payload.html && payload.elementMap) {
+                    setRenderResult(payload.html, payload.elementMap);
+                  }
+                }
+              } catch {
+                // Java server not running
               }
-            }
-          } catch {
-            // Java server not running – preview will show a placeholder
-          }
-        })(),
+            })(),
       ]);
       setLoadedDocument({
         fileName: file.name,
@@ -253,15 +406,58 @@ export default function Home() {
       setOutline(buildOutlineFromDoc(parsed.doc));
       setStatus(
         parsed.integrityIssues.length
-          ? `로드 완료: 세그먼트 ${parsed.segments.length}개 (무결성 경고 ${parsed.integrityIssues.length}개)`
+          ? `로드 완료: 세그먼트 ${parsed.segments.length}개 (경고 ${parsed.integrityIssues.length}개)`
           : `로드 완료: 세그먼트 ${parsed.segments.length}개`,
       );
+
+      // Phase 2-4: Auto-analyze document on upload
+      fireDocumentAnalysis(parsed.segments);
     } catch (error) {
       const message = error instanceof Error ? error.message : "문서 로드 실패";
       setStatus(message);
     } finally {
       setBusy(false);
     }
+  };
+
+  /* ── Phase 2-4: Document Analysis ── */
+  const fireDocumentAnalysis = (segments: Array<{ segmentId: string; text: string }>) => {
+    setAnalysisLoading(true);
+    const items = segments
+      .filter((s) => s.text.trim())
+      .slice(0, 100)
+      .map((s) => ({
+        id: s.segmentId,
+        text: s.text.slice(0, 200),
+      }));
+    if (!items.length) {
+      setAnalysisLoading(false);
+      return;
+    }
+    fetch("/api/analyze-document", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ segments: items }),
+    })
+      .then(async (resp) => {
+        if (!resp.ok) return;
+        const data = await resp.json();
+        setDocumentAnalysis(data);
+        // Auto-select preset if suggested
+        if (data.suggestedPreset) {
+          const preset = INSTRUCTION_PRESETS.find((p) => p.key === data.suggestedPreset);
+          if (preset) {
+            setSelectedPreset(preset.key);
+            if (preset.instruction) {
+              setInstruction(preset.instruction);
+            }
+          }
+        }
+      })
+      .catch(() => {
+        // Analysis is optional
+      })
+      .finally(() => setAnalysisLoading(false));
   };
 
   const onEditorUpdateDoc = (doc: Parameters<typeof setEditorDoc>[0]) => {
@@ -280,6 +476,7 @@ export default function Home() {
     }
     setAiBusy(true);
     setActiveSidebarTab("ai");
+    setVerificationResult(null);
     setStatus("AI 제안을 생성 중입니다...");
     try {
       const response = await fetch("/api/suggest", {
@@ -329,9 +526,15 @@ export default function Home() {
     setStatus(replaced ? "문단 전체에 AI 제안을 적용했습니다." : "대상 문단을 찾지 못했습니다.");
   };
 
+  const isHwpxFile = fileName.toLowerCase().endsWith(".hwpx");
+
   const onExport = async () => {
     if (!sourceBuffer || !editorDoc) {
-      setStatus("먼저 HWPX 파일을 업로드하세요.");
+      setStatus("먼저 문서 파일을 업로드하세요.");
+      return;
+    }
+    if (!isHwpxFile) {
+      setStatus("DOCX 파일은 아직 HWPX 내보내기만 지원합니다. PDF/DOCX 내보내기는 곧 지원 예정입니다.");
       return;
     }
     setBusy(true);
@@ -360,6 +563,21 @@ export default function Home() {
     }
   };
 
+  /* ── Ctrl+S 저장 단축키 ── */
+  const onExportRef = useRef(onExport);
+  onExportRef.current = onExport;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        onExportRef.current();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   const onSelectOutlineSegment = (segmentId: string) => {
     if (!editor) {
       setStatus("에디터가 아직 준비되지 않았습니다.");
@@ -373,6 +591,7 @@ export default function Home() {
     setStatus("개요에서 문단으로 이동했습니다.");
   };
 
+  /* ── Phase 2-7: Progressive batch suggestions ── */
   const onGenerateBatchSuggestions = async () => {
     if (!editorDoc) {
       setStatus("먼저 HWPX 파일을 업로드하세요.");
@@ -385,42 +604,46 @@ export default function Home() {
 
     setAiBusy(true);
     setActiveSidebarTab("ai");
+    clearBatchDecisions();
+    setBatchSuggestions([]);
+
     const chunks: Array<typeof batchItems> = [];
     for (let index = 0; index < batchItems.length; index += BATCH_API_CHUNK_SIZE) {
       chunks.push(batchItems.slice(index, index + BATCH_API_CHUNK_SIZE));
     }
-    setStatus(`AI 섹션 일괄 제안을 생성 중입니다... (${batchItems.length}개 / ${chunks.length}회 요청)`);
+
+    let accumulated: Array<{ id: string; suggestion: string }> = [];
+
     try {
-      const responses = await Promise.all(
-        chunks.map(async (chunk) => {
-          const response = await fetch("/api/suggest-batch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              items: chunk,
-              instruction,
-              model: undefined,
-            }),
-          });
-          const payload = (await response.json()) as {
-            results?: Array<{ id?: string; suggestion?: string }>;
-            error?: string;
-          };
-          if (!response.ok) {
-            throw new Error(payload.error || "AI 일괄 제안 생성 실패");
-          }
-          return payload.results || [];
-        }),
-      );
-      const next = responses
-        .flat()
-        .map((row) => ({
-          id: String(row.id || "").trim(),
-          suggestion: String(row.suggestion || "").trim(),
-        }))
-        .filter((row) => row.id && row.suggestion);
-      setBatchSuggestions(next);
-      const nextPlan = buildBatchApplyPlan(batchItems, next);
+      for (let ci = 0; ci < chunks.length; ci++) {
+        setStatus(`AI 생성 중... (${ci + 1}/${chunks.length})`);
+        const chunk = chunks[ci];
+        const response = await fetch("/api/suggest-batch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            items: chunk,
+            instruction,
+            model: undefined,
+          }),
+        });
+        const payload = (await response.json()) as {
+          results?: Array<{ id?: string; suggestion?: string }>;
+          error?: string;
+        };
+        if (!response.ok) {
+          throw new Error(payload.error || "AI 일괄 제안 생성 실패");
+        }
+        const chunkResults = (payload.results || [])
+          .map((row) => ({
+            id: String(row.id || "").trim(),
+            suggestion: String(row.suggestion || "").trim(),
+          }))
+          .filter((row) => row.id && row.suggestion);
+        accumulated = [...accumulated, ...chunkResults];
+        setBatchSuggestions([...accumulated]); // progressive UI update
+      }
+      const nextPlan = buildBatchApplyPlan(batchItems, accumulated);
       const changedCount = nextPlan.filter((row) => row.changed).length;
       setStatus(`AI 섹션 일괄 제안 완료: 대상 ${nextPlan.length}개 중 변경 ${changedCount}개`);
     } catch (error) {
@@ -453,38 +676,637 @@ export default function Home() {
       return;
     }
     setBatchSuggestions([]);
+    clearBatchDecisions();
     pushHistory(`AI 섹션 일괄 적용 (${appliedCount}건)`, appliedCount);
     setStatus(`AI 섹션 일괄 적용 완료: ${appliedCount}건`);
   };
 
+  /* ── Phase 2-1: Apply only accepted batch suggestions ── */
+  const onApplySelectedBatchSuggestions = () => {
+    if (!editor) {
+      setStatus("에디터가 아직 준비되지 않았습니다.");
+      return;
+    }
+    const acceptedIds = new Set(
+      Object.entries(batchDecisions)
+        .filter(([, decision]) => decision === "accepted")
+        .map(([id]) => id),
+    );
+    if (!acceptedIds.size) {
+      setStatus("수락된 항목이 없습니다.");
+      return;
+    }
+    const plan = buildBatchApplyPlan(batchItems, batchSuggestions)
+      .filter((item) => item.changed && acceptedIds.has(item.id));
+    const appliedCount = applyBatchSegmentTexts(
+      editor,
+      plan.map((item) => ({
+        segmentId: item.id,
+        text: item.suggestion,
+      })),
+    );
+    if (!appliedCount) {
+      setStatus("적용 가능한 변경이 없습니다.");
+      return;
+    }
+    setBatchSuggestions([]);
+    clearBatchDecisions();
+    pushHistory(`AI 선택 적용 (${appliedCount}건)`, appliedCount);
+    setStatus(`AI 선택 적용 완료: ${appliedCount}건`);
+  };
+
+  /* ── Phase 2-6: Verify AI suggestion ── */
+  const onVerifySuggestion = async () => {
+    const text = selection.selectedText.trim();
+    if (!text || !aiSuggestion.trim()) {
+      setStatus("검증할 원문과 AI 제안이 필요합니다.");
+      return;
+    }
+    setVerificationLoading(true);
+    setVerificationResult(null);
+    try {
+      const resp = await fetch("/api/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          originalText: text,
+          modifiedText: aiSuggestion,
+          instruction,
+        }),
+      });
+      const data = await resp.json();
+      if (!resp.ok) {
+        throw new Error(data.error || "검증 실패");
+      }
+      setVerificationResult(data);
+      setStatus(data.passed ? "검증 통과" : `검증 이슈 ${data.issues?.length || 0}건`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "검증 실패";
+      setStatus(message);
+    } finally {
+      setVerificationLoading(false);
+    }
+  };
+
+  /* ── Phase 2-5: Apply terminology replacements ── */
+  const onApplyTerminology = () => {
+    if (!editor) {
+      setStatus("에디터가 아직 준비되지 않았습니다.");
+      return;
+    }
+    const entries = Object.entries(terminologyDict);
+    if (!entries.length) {
+      setStatus("용어 사전이 비어 있습니다.");
+      return;
+    }
+
+    let totalReplaced = 0;
+    let tr = editor.state.tr;
+    editor.state.doc.descendants((node, pos) => {
+      if (!node.isText || !node.text) return true;
+      let text = node.text;
+      let modified = false;
+      for (const [variant, canonical] of entries) {
+        if (text.includes(variant)) {
+          text = text.split(variant).join(canonical);
+          modified = true;
+        }
+      }
+      if (modified) {
+        const from = pos;
+        const to = pos + node.nodeSize;
+        tr = tr.replaceWith(from, to, editor.schema.text(text, node.marks));
+        totalReplaced++;
+      }
+      return true;
+    });
+    if (tr.docChanged) {
+      editor.view.dispatch(tr.scrollIntoView());
+      pushHistory(`용어 일괄 치환 (${totalReplaced}건)`, totalReplaced);
+      setStatus(`용어 일괄 치환 완료: ${totalReplaced}건`);
+    } else {
+      setStatus("치환할 용어가 문서에 없습니다.");
+    }
+  };
+
+  /* ── Phase 2-3: Preset selection ── */
+  const onSelectPreset = (key: PresetKey) => {
+    setSelectedPreset(key);
+    const preset = INSTRUCTION_PRESETS.find((p) => p.key === key);
+    if (preset && preset.instruction) {
+      setInstruction(preset.instruction);
+    }
+  };
+
+  /* ── Chat agent: build DocumentContext for API ── */
+  const buildDocumentContext = useCallback((): DocumentContext => {
+    const liveDoc = (editor?.getJSON() as JSONContent | undefined) || editorDoc;
+    if (!liveDoc) {
+      return {
+        segments: sourceSegments.map((s) => ({
+          segmentId: s.segmentId,
+          text: s.text,
+          tag: s.tag === "t" ? "p" : s.tag,
+          styleHints: s.styleHints,
+        })),
+        fileName,
+      };
+    }
+
+    const sourceBySegmentId = new Map(sourceSegments.map((s) => [s.segmentId, s]));
+    const segments: DocumentContext["segments"] = [];
+
+    const walk = (node: JSONContent): void => {
+      if (node.type === "paragraph" || node.type === "heading") {
+        const attrs = (node.attrs || {}) as { segmentId?: string; level?: number };
+        if (attrs.segmentId) {
+          const source = sourceBySegmentId.get(attrs.segmentId);
+          const headingLevel = Number(attrs.level || 2);
+          const tag =
+            node.type === "heading"
+              ? `h${Math.max(1, Math.min(6, Number.isFinite(headingLevel) ? headingLevel : 2))}`
+              : "p";
+          segments.push({
+            segmentId: attrs.segmentId,
+            text: extractNodeText(node),
+            tag,
+            styleHints: source?.styleHints || {},
+          });
+        }
+      }
+      for (const child of node.content || []) {
+        walk(child);
+      }
+    };
+
+    walk(liveDoc);
+
+    return {
+      segments,
+      fileName,
+    };
+  }, [editor, editorDoc, sourceSegments, fileName]);
+
+  /* ── Chat agent: build EditPreview from a write tool call ── */
+  const buildEditPreview = useCallback(
+    (toolCall: ToolCallInfo): EditPreview => {
+      const input = toolCall.input;
+      const contextBySegmentId = new Map(
+        buildDocumentContext().segments.map((segment) => [segment.segmentId, segment]),
+      );
+      if (toolCall.name === "edit_segment") {
+        const seg = contextBySegmentId.get(String(input.segmentId));
+        return {
+          edits: [
+            {
+              segmentId: input.segmentId as string,
+              before: seg?.text || "",
+              after: input.newText as string,
+            },
+          ],
+          summary: "1개 문단 수정",
+        };
+      }
+      if (toolCall.name === "edit_segments") {
+        const edits = (input.edits as Array<{ segmentId: string; newText: string }>).map((e) => {
+          const seg = contextBySegmentId.get(e.segmentId);
+          return { segmentId: e.segmentId, before: seg?.text || "", after: e.newText };
+        });
+        return { edits, summary: `${edits.length}개 문단 수정` };
+      }
+      if (toolCall.name === "search_replace") {
+        const search = input.search as string;
+        const replace = input.replace as string;
+        const caseSensitive = input.caseSensitive === undefined ? true : Boolean(input.caseSensitive);
+        const affected = Array.from(contextBySegmentId.values())
+          .map((segment) => {
+            const replaced = applySearchReplace(segment.text, search, replace, caseSensitive);
+            if (!replaced.replacements) {
+              return null;
+            }
+            return {
+              segmentId: segment.segmentId,
+              before: segment.text,
+              after: replaced.nextText,
+            };
+          })
+          .filter((row): row is { segmentId: string; before: string; after: string } => !!row);
+        return {
+          edits: affected,
+          summary: `"${search}" → "${replace}" (${affected.length}건)`,
+        };
+      }
+      return { edits: [], summary: "" };
+    },
+    [buildDocumentContext],
+  );
+
+  /* ── Chat agent: convert UI messages to API format ── */
+  const buildApiMessages = useCallback((): ChatMessageAPI[] => {
+    const apiMessages: ChatMessageAPI[] = [];
+
+    for (const message of chatMessages) {
+      if (message.role === "user") {
+        if (message.content.trim()) {
+          apiMessages.push({
+            role: "user",
+            content: message.content,
+          });
+        }
+        continue;
+      }
+
+      const assistantBlocks: Array<{
+        type: "text";
+        text: string;
+      } | {
+        type: "tool_use";
+        id: string;
+        name: string;
+        input: Record<string, unknown>;
+      }> = [];
+
+      if (message.content.trim()) {
+        assistantBlocks.push({ type: "text", text: message.content });
+      }
+      for (const toolCall of message.toolCalls || []) {
+        assistantBlocks.push({
+          type: "tool_use",
+          id: toolCall.id,
+          name: toolCall.name,
+          input: toolCall.input,
+        });
+      }
+
+      if (assistantBlocks.length === 1 && assistantBlocks[0].type === "text") {
+        apiMessages.push({
+          role: "assistant",
+          content: message.content,
+        });
+      } else if (assistantBlocks.length > 1 || message.toolCalls?.length) {
+        apiMessages.push({
+          role: "assistant",
+          content: assistantBlocks,
+        });
+      }
+
+      if (message.toolResults?.length) {
+        apiMessages.push({
+          role: "user",
+          content: message.toolResults.map((toolResult) => ({
+            type: "tool_result" as const,
+            tool_use_id: toolResult.toolCallId,
+            content:
+              typeof toolResult.result === "string"
+                ? toolResult.result
+                : JSON.stringify(toolResult.result),
+          })),
+        });
+      }
+    }
+
+    return apiMessages;
+  }, [chatMessages]);
+
+  /* ── Chat agent: send message ── */
+  const onSendChatMessage = useCallback(
+    async (text: string) => {
+      const userMsgId = `user-${Date.now()}`;
+      addChatMessage({
+        id: userMsgId,
+        role: "user",
+        content: text,
+        timestamp: Date.now(),
+      });
+
+      setChatBusy(true);
+
+      const assistantMsgId = `assistant-${Date.now()}`;
+      addChatMessage({
+        id: assistantMsgId,
+        role: "assistant",
+        content: "",
+        timestamp: Date.now(),
+        isStreaming: true,
+      });
+
+      const apiMessages = buildApiMessages();
+      apiMessages.push({ role: "user", content: text });
+
+      try {
+        await streamChat(
+          {
+            messages: apiMessages,
+            documentContext: buildDocumentContext(),
+          },
+          {
+            onTextDelta: (delta) => {
+              updateLastAssistantMessage((prev) => prev + delta);
+            },
+            onToolCall: (tc) => {
+              appendToolCallToLastMessage(tc);
+            },
+            onToolResult: (tr) => {
+              appendToolResultToLastMessage(tr);
+            },
+            onToolPending: (tc) => {
+              const preview = buildEditPreview(tc);
+              setPendingToolCall({ toolCall: tc, preview });
+            },
+            onDone: () => {
+              finalizeLastAssistantMessage();
+              setChatBusy(false);
+            },
+            onError: (msg) => {
+              updateLastAssistantMessage((prev) =>
+                prev + (prev ? "\n" : "") + `오류: ${msg}`,
+              );
+              finalizeLastAssistantMessage();
+              setChatBusy(false);
+            },
+          },
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "채팅 오류";
+        updateLastAssistantMessage((prev) =>
+          prev + (prev ? "\n" : "") + `오류: ${message}`,
+        );
+        finalizeLastAssistantMessage();
+        setChatBusy(false);
+      }
+    },
+    [
+      addChatMessage,
+      setChatBusy,
+      updateLastAssistantMessage,
+      finalizeLastAssistantMessage,
+      appendToolCallToLastMessage,
+      appendToolResultToLastMessage,
+      setPendingToolCall,
+      buildApiMessages,
+      buildDocumentContext,
+      buildEditPreview,
+    ],
+  );
+
+  /* ── Chat agent: approve pending tool ── */
+  const onApproveToolCall = useCallback(() => {
+    if (!pendingToolCall || !editor) return;
+    const { toolCall } = pendingToolCall;
+    let resultMsg = "적용 완료";
+
+    if (toolCall.name === "edit_segment") {
+      const ok = replaceSegmentText(
+        editor,
+        toolCall.input.segmentId as string,
+        toolCall.input.newText as string,
+      );
+      resultMsg = ok ? "1개 문단 수정 완료" : "대상 문단을 찾지 못했습니다";
+    } else if (toolCall.name === "edit_segments") {
+      const edits = toolCall.input.edits as Array<{ segmentId: string; newText: string }>;
+      const count = applyBatchSegmentTexts(
+        editor,
+        edits.map((e) => ({ segmentId: e.segmentId, text: e.newText })),
+      );
+      resultMsg = `${count}개 문단 수정 완료`;
+      pushHistory(`AI 채팅 일괄 수정 (${count}건)`, count);
+    } else if (toolCall.name === "search_replace") {
+      const search = toolCall.input.search as string;
+      const replace = toolCall.input.replace as string;
+      const caseSensitive =
+        toolCall.input.caseSensitive === undefined
+          ? true
+          : Boolean(toolCall.input.caseSensitive);
+      let totalMatched = 0;
+      let totalReplacedSegments = 0;
+      const replacements: Array<{
+        from: number;
+        to: number;
+        text: string;
+        marks: PMNode["marks"];
+      }> = [];
+
+      editor.state.doc.descendants((node, pos) => {
+        if (!node.isText || !node.text) return true;
+        const replaced = applySearchReplace(node.text, search, replace, caseSensitive);
+        if (replaced.replacements > 0) {
+          replacements.push({
+            from: pos,
+            to: pos + node.nodeSize,
+            text: replaced.nextText,
+            marks: node.marks,
+          });
+          totalMatched += replaced.replacements;
+          totalReplacedSegments += 1;
+        }
+        return true;
+      });
+
+      let tr = editor.state.tr;
+      replacements.sort((a, b) => b.from - a.from);
+      for (const replacement of replacements) {
+        tr = tr.replaceWith(
+          replacement.from,
+          replacement.to,
+          editor.schema.text(replacement.text, replacement.marks),
+        );
+      }
+
+      if (tr.docChanged) {
+        editor.view.dispatch(tr.scrollIntoView());
+      }
+      resultMsg = `${totalReplacedSegments}개 세그먼트 치환 완료 (${totalMatched}회 일치)`;
+      pushHistory(`AI 채팅 찾아바꾸기 (${totalReplacedSegments}건)`, totalReplacedSegments);
+    }
+
+    setPendingToolCall(null);
+
+    // Continue the conversation with the tool result
+    const continuationMessages = buildApiMessages();
+
+    addChatMessage({
+      id: `assistant-continue-${Date.now()}`,
+      role: "assistant",
+      content: "",
+      timestamp: Date.now(),
+      isStreaming: true,
+    });
+
+    setChatBusy(true);
+
+    streamChat(
+      {
+        messages: continuationMessages,
+        documentContext: buildDocumentContext(),
+        approvedToolCall: {
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          result: resultMsg,
+        },
+      },
+      {
+        onTextDelta: (delta) => {
+          updateLastAssistantMessage((prev) => prev + delta);
+        },
+        onToolCall: (tc) => {
+          appendToolCallToLastMessage(tc);
+        },
+        onToolResult: (tr) => {
+          appendToolResultToLastMessage(tr);
+        },
+        onToolPending: (tc) => {
+          const preview = buildEditPreview(tc);
+          setPendingToolCall({ toolCall: tc, preview });
+        },
+        onDone: () => {
+          finalizeLastAssistantMessage();
+          setChatBusy(false);
+        },
+        onError: (msg) => {
+          updateLastAssistantMessage((prev) =>
+            prev + (prev ? "\n" : "") + `오류: ${msg}`,
+          );
+          finalizeLastAssistantMessage();
+          setChatBusy(false);
+        },
+      },
+    ).catch(() => {
+      setChatBusy(false);
+    });
+  }, [
+    pendingToolCall,
+    editor,
+    setPendingToolCall,
+    setChatBusy,
+    addChatMessage,
+    updateLastAssistantMessage,
+    finalizeLastAssistantMessage,
+    appendToolCallToLastMessage,
+    appendToolResultToLastMessage,
+    buildApiMessages,
+    buildDocumentContext,
+    buildEditPreview,
+    pushHistory,
+  ]);
+
+  /* ── Chat agent: reject pending tool ── */
+  const onRejectToolCall = useCallback(() => {
+    if (!pendingToolCall) return;
+    const { toolCall } = pendingToolCall;
+    setPendingToolCall(null);
+
+    // Continue conversation telling the agent the tool was rejected
+    const continuationMessages = buildApiMessages();
+
+    addChatMessage({
+      id: `assistant-reject-${Date.now()}`,
+      role: "assistant",
+      content: "",
+      timestamp: Date.now(),
+      isStreaming: true,
+    });
+
+    setChatBusy(true);
+
+    streamChat(
+      {
+        messages: continuationMessages,
+        documentContext: buildDocumentContext(),
+        approvedToolCall: {
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          result: "사용자가 이 수정을 거부했습니다. 다른 방법을 제안하거나 사용자의 추가 지시를 기다려주세요.",
+        },
+      },
+      {
+        onTextDelta: (delta) => {
+          updateLastAssistantMessage((prev) => prev + delta);
+        },
+        onToolCall: (tc) => {
+          appendToolCallToLastMessage(tc);
+        },
+        onToolResult: (tr) => {
+          appendToolResultToLastMessage(tr);
+        },
+        onToolPending: (tc) => {
+          const preview = buildEditPreview(tc);
+          setPendingToolCall({ toolCall: tc, preview });
+        },
+        onDone: () => {
+          finalizeLastAssistantMessage();
+          setChatBusy(false);
+        },
+        onError: (msg) => {
+          updateLastAssistantMessage((prev) =>
+            prev + (prev ? "\n" : "") + `오류: ${msg}`,
+          );
+          finalizeLastAssistantMessage();
+          setChatBusy(false);
+        },
+      },
+    ).catch(() => {
+      setChatBusy(false);
+    });
+  }, [
+    pendingToolCall,
+    setPendingToolCall,
+    setChatBusy,
+    addChatMessage,
+    updateLastAssistantMessage,
+    finalizeLastAssistantMessage,
+    appendToolCallToLastMessage,
+    appendToolResultToLastMessage,
+    buildApiMessages,
+    buildDocumentContext,
+    buildEditPreview,
+  ]);
+
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div>
-          <h1>HWPX Interactive WYSIWYG Editor</h1>
-          <p>한글 문서를 실제 문서처럼 보면서 편집하고, 손상 방지 검증 후 다시 HWPX로 저장합니다.</p>
-        </div>
-        <div className={styles.headerActions}>
-          <FileUpload disabled={isBusy} onPickFile={onPickFile} />
-          <DownloadButton
-            onGenerate={onExport}
-            disabled={isBusy || !editorDoc}
-            downloadUrl={downloadUrl}
-            downloadName={download.fileName}
-          />
-        </div>
-      </header>
-
+      {/* ── HWP-style 통합 툴바 ── */}
       <EditorToolbar
         editor={editor}
         sidebarCollapsed={sidebarCollapsed}
+        activeSidebarTab={activeSidebarTab}
+        disabled={isBusy}
+        hasDocument={!!editorDoc}
+        downloadUrl={downloadUrl}
+        downloadName={download.fileName}
         onToggleSidebar={toggleSidebar}
+        onSetSidebarTab={handleSetSidebarTab}
         onAiCommand={() => {
           setActiveSidebarTab("ai");
           void onGenerateSuggestion();
         }}
+        onPickFile={onPickFile}
+        onExport={onExport}
+        onExportPdf={() => {
+          const editorWrap = document.querySelector(".document-editor-wrap");
+          if (editorWrap) exportToPdf(editorWrap as HTMLElement, fileName || "document");
+          else setStatus("에디터를 찾을 수 없습니다.");
+        }}
+        onExportDocx={async () => {
+          if (!editorDoc) {
+            setStatus("먼저 문서를 업로드하세요.");
+            return;
+          }
+          setBusy(true);
+          setStatus("DOCX 파일을 생성하고 있습니다...");
+          try {
+            const result = await exportToDocx(editorDoc, fileName || "document");
+            setDownload({ blob: result.blob, fileName: result.fileName });
+            setStatus(`DOCX 내보내기 완료: ${result.fileName}`);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "DOCX 내보내기 실패";
+            setStatus(message);
+          } finally {
+            setBusy(false);
+          }
+        }}
+        onSave={onExport}
       />
 
+      {/* ── 경고 배너 ── */}
       {integrityIssues.length ? (
         <div className={styles.warning}>
           <strong>무결성 경고</strong>
@@ -493,7 +1315,6 @@ export default function Home() {
           ))}
         </div>
       ) : null}
-
       {exportWarnings.length ? (
         <div className={styles.warningSoft}>
           <strong>내보내기 주의</strong>
@@ -503,60 +1324,80 @@ export default function Home() {
         </div>
       ) : null}
 
+      {/* ── 메인: 에디터 캔버스 + 사이드바 ── */}
       <main className={styles.main}>
         <section className={styles.editorArea}>
-          {editorDoc ? (
-            <div className={styles.viewTabs}>
-              <button
-                className={`${styles.viewTabBtn} ${viewMode === "editor" ? styles.viewTabBtnActive : ""}`}
-                onClick={() => setViewMode("editor")}
-              >
-                편집
-              </button>
-              <button
-                className={`${styles.viewTabBtn} ${viewMode === "preview" ? styles.viewTabBtnActive : ""}`}
-                onClick={() => setViewMode("preview")}
-                disabled={!renderHtml}
-                title={renderHtml ? undefined : "Java 서버에 연결되지 않았습니다"}
-              >
-                미리보기
-              </button>
+          <div className={styles.editorCenter}>
+            {editorDoc ? (
+              <div className={styles.viewTabs}>
+                <button
+                  type="button"
+                  className={`${styles.viewTabBtn} ${viewMode === "editor" ? styles.viewTabBtnActive : ""}`}
+                  onClick={() => setViewMode("editor")}
+                >
+                  편집
+                </button>
+                <button
+                  type="button"
+                  className={`${styles.viewTabBtn} ${viewMode === "preview" ? styles.viewTabBtnActive : ""}`}
+                  onClick={() => setViewMode("preview")}
+                  disabled={!renderHtml}
+                  title={renderHtml ? undefined : "Java 서버에 연결되지 않았습니다"}
+                >
+                  미리보기
+                </button>
+              </div>
+            ) : null}
+
+            <EditorRuler />
+
+            {/* 편집 탭 */}
+            <div style={{ display: viewMode === "editor" ? "block" : "none" }}>
+              <EditorLayout>
+                <DocumentEditor
+                  content={editorDoc}
+                  onUpdateDoc={onEditorUpdateDoc}
+                  onSelectionChange={setSelection}
+                  onEditorReady={setEditor}
+                  onAiCommand={() => {
+                    setActiveSidebarTab("ai");
+                    void onGenerateSuggestion();
+                  }}
+                  onDiffSegmentClick={(segmentId) => {
+                    if (sidebarCollapsed) toggleSidebar();
+                    setActiveSidebarTab("ai");
+                    setTimeout(() => {
+                      const el = document.querySelector(`[data-batch-diff-id="${segmentId}"]`);
+                      el?.scrollIntoView({ behavior: "smooth", block: "center" });
+                    }, 100);
+                  }}
+                />
+              </EditorLayout>
             </div>
-          ) : null}
-          <div style={{ display: viewMode === "editor" ? "block" : "none" }}>
-            <DocumentEditor
-              content={editorDoc}
-              onUpdateDoc={onEditorUpdateDoc}
-              onSelectionChange={setSelection}
-              onEditorReady={setEditor}
-              onAiCommand={() => {
-                setActiveSidebarTab("ai");
-                void onGenerateSuggestion();
-              }}
-            />
+
+            {/* 미리보기 탭 */}
+            {viewMode === "preview" && renderHtml ? (
+              <div
+                className={styles.previewPane}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted Java server output
+                dangerouslySetInnerHTML={{ __html: renderHtml }}
+                onClick={(e) => {
+                  const target = (e.target as HTMLElement).closest("[data-segment-id]");
+                  if (!target) return;
+                  const segmentId = target.getAttribute("data-segment-id");
+                  if (!segmentId) return;
+                  setViewMode("editor");
+                  setSelection({ selectedSegmentId: segmentId, selectedText: renderElementMap?.[segmentId]?.text ?? "" });
+                  if (editor) focusSegment(editor, segmentId);
+                }}
+              />
+            ) : null}
           </div>
-          {viewMode === "preview" && renderHtml ? (
-            <div
-              className={styles.previewPane}
-              // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted Java server output
-              dangerouslySetInnerHTML={{ __html: renderHtml }}
-              onClick={(e) => {
-                const target = (e.target as HTMLElement).closest("[data-segment-id]");
-                if (!target) return;
-                const segmentId = target.getAttribute("data-segment-id");
-                if (!segmentId) return;
-                setViewMode("editor");
-                setSelection({ selectedSegmentId: segmentId, selectedText: renderElementMap?.[segmentId]?.text ?? "" });
-                if (editor) focusSegment(editor, segmentId);
-              }}
-            />
-          ) : null}
         </section>
 
         <Sidebar
           collapsed={sidebarCollapsed}
           activeTab={activeSidebarTab}
-          onChangeTab={setActiveSidebarTab}
           outline={
             <DocumentOutline
               outline={outline}
@@ -578,12 +1419,47 @@ export default function Home() {
               onApplySuggestion={onApplySuggestion}
               onRequestBatchSuggestion={() => void onGenerateBatchSuggestions()}
               onApplyBatchSuggestion={onApplyBatchSuggestions}
+              batchDecisions={batchDecisions}
+              onSetBatchDecision={setBatchDecision}
+              onApplySelectedBatchSuggestion={onApplySelectedBatchSuggestions}
+              presets={INSTRUCTION_PRESETS}
+              selectedPreset={selectedPreset}
+              onSelectPreset={onSelectPreset}
+              verificationResult={verificationResult}
+              verificationLoading={verificationLoading}
+              onVerifySuggestion={() => void onVerifySuggestion()}
+              batchMode={batchMode}
+              onSetBatchMode={setBatchMode}
+            />
+          }
+          chat={
+            <ChatPanel
+              messages={chatMessages}
+              isBusy={chatBusy}
+              pendingToolCall={pendingToolCall}
+              hasDocument={!!editorDoc}
+              onSendMessage={(text) => void onSendChatMessage(text)}
+              onApproveTool={onApproveToolCall}
+              onRejectTool={onRejectToolCall}
+              onClearChat={clearChat}
+            />
+          }
+          analysis={
+            <DocumentAnalysisPanel
+              analysis={documentAnalysis}
+              isLoading={analysisLoading}
+              terminologyDict={terminologyDict}
+              onUpdateEntry={updateTerminologyEntry}
+              onRemoveEntry={removeTerminologyEntry}
+              onApplyTerminology={onApplyTerminology}
+              isBusy={isBusy}
             />
           }
           history={<EditHistoryPanel history={history} />}
         />
       </main>
 
+      {/* ── 하단 상태 표시줄 ── */}
       <StatusBar
         fileName={fileName}
         nodeCount={sourceSegments.length}

--- a/src/components/editor/CharStyleModal.tsx
+++ b/src/components/editor/CharStyleModal.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import type { Editor } from "@tiptap/core";
+import styles from "./StyleModal.module.css";
+
+const HWP_FONTS = [
+  "바탕", "바탕체", "궁서", "궁서체", "굴림", "굴림체", "돋움", "돋움체",
+  "맑은 고딕", "나눔고딕", "나눔명조", "Arial", "Times New Roman",
+];
+
+const FONT_SIZES = [7, 8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32, 36, 40, 48, 72];
+
+type CharStyleState = {
+  fontFamily: string;
+  fontSize: number;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+  textColor: string;
+  bgColor: string;
+};
+
+function readCurrentCharStyle(editor: Editor): CharStyleState {
+  const tsAttrs = editor.getAttributes("textStyle") as {
+    fontFamily?: string;
+    fontSize?: string;
+    color?: string;
+  };
+  const sizePx = Number.parseInt(tsAttrs.fontSize ?? "0", 10);
+  return {
+    fontFamily: tsAttrs.fontFamily || "바탕",
+    fontSize: sizePx > 0 ? sizePx : 10,
+    bold: editor.isActive("bold"),
+    italic: editor.isActive("italic"),
+    underline: editor.isActive("underline"),
+    strikethrough: editor.isActive("strike"),
+    textColor: tsAttrs.color || "#000000",
+    bgColor: "#ffffff",
+  };
+}
+
+type CharStyleModalProps = {
+  editor: Editor;
+  onClose: () => void;
+};
+
+export function CharStyleModal({ editor, onClose }: CharStyleModalProps) {
+  const [state, setState] = useState<CharStyleState>(() => readCurrentCharStyle(editor));
+
+  const update = <K extends keyof CharStyleState>(key: K, value: CharStyleState[K]) => {
+    setState((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const onApply = () => {
+    const chain = editor.chain().focus();
+
+    // Font
+    chain.setFontFamily(state.fontFamily);
+    chain.setMark("textStyle", { fontSize: `${state.fontSize}pt` });
+
+    // Bold / Italic / Underline / Strike
+    if (state.bold) chain.setBold(); else chain.unsetBold();
+    if (state.italic) chain.setItalic(); else chain.unsetItalic();
+    if (state.underline) chain.setUnderline(); else chain.unsetUnderline();
+    if (state.strikethrough) chain.setStrike(); else chain.unsetStrike();
+
+    chain.run();
+    onClose();
+  };
+
+  const preview: React.CSSProperties = {
+    fontFamily: state.fontFamily,
+    fontSize: `${state.fontSize}pt`,
+    fontWeight: state.bold ? "bold" : "normal",
+    fontStyle: state.italic ? "italic" : "normal",
+    textDecoration: [
+      state.underline ? "underline" : "",
+      state.strikethrough ? "line-through" : "",
+    ]
+      .filter(Boolean)
+      .join(" ") || "none",
+    color: state.textColor,
+    backgroundColor: state.bgColor,
+  };
+
+  return (
+    <div className={styles.backdrop} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.titleBar}>
+          <span>글자 모양</span>
+          <button type="button" className={styles.closeBtn} onClick={onClose}>✕</button>
+        </div>
+
+        <div className={styles.body}>
+          {/* ── 기본 설정 ── */}
+          <fieldset className={styles.fieldset}>
+            <legend>글꼴</legend>
+            <div className={styles.grid2}>
+              <label className={styles.numField}>
+                <span className={styles.numLabel}>글꼴</span>
+                <select
+                  className={styles.select}
+                  value={state.fontFamily}
+                  onChange={(e) => update("fontFamily", e.target.value)}
+                >
+                  {HWP_FONTS.map((f) => (
+                    <option key={f} value={f} style={{ fontFamily: f }}>
+                      {f}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className={styles.numField}>
+                <span className={styles.numLabel}>크기 (pt)</span>
+                <select
+                  className={styles.select}
+                  value={state.fontSize}
+                  onChange={(e) => update("fontSize", Number(e.target.value))}
+                >
+                  {FONT_SIZES.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </fieldset>
+
+          {/* ── 속성 ── */}
+          <fieldset className={styles.fieldset}>
+            <legend>속성</legend>
+            <div className={styles.checkRow}>
+              <CheckBox label="굵게" checked={state.bold} onChange={(v) => update("bold", v)} />
+              <CheckBox label="기울임" checked={state.italic} onChange={(v) => update("italic", v)} />
+              <CheckBox label="밑줄" checked={state.underline} onChange={(v) => update("underline", v)} />
+              <CheckBox label="취소선" checked={state.strikethrough} onChange={(v) => update("strikethrough", v)} />
+            </div>
+          </fieldset>
+
+          {/* ── 색상 ── */}
+          <fieldset className={styles.fieldset}>
+            <legend>색상</legend>
+            <div className={styles.colorRow}>
+              <label className={styles.colorField}>
+                <span>글자 색</span>
+                <input
+                  type="color"
+                  value={state.textColor}
+                  onChange={(e) => update("textColor", e.target.value)}
+                />
+              </label>
+              <label className={styles.colorField}>
+                <span>배경 색</span>
+                <input
+                  type="color"
+                  value={state.bgColor}
+                  onChange={(e) => update("bgColor", e.target.value)}
+                />
+              </label>
+            </div>
+          </fieldset>
+
+          {/* ── 미리보기 ── */}
+          <fieldset className={styles.fieldset}>
+            <legend>미리보기</legend>
+            <div className={styles.preview} style={preview}>
+              가나다 AaBbCc 123 한글 영문
+            </div>
+          </fieldset>
+        </div>
+
+        <div className={styles.footer}>
+          <button type="button" className={styles.applyBtn} onClick={onApply}>설정</button>
+          <button type="button" className={styles.cancelBtn} onClick={onClose}>취소</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CheckBox({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className={styles.checkLabel}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  );
+}

--- a/src/components/editor/DocumentEditor.tsx
+++ b/src/components/editor/DocumentEditor.tsx
@@ -18,6 +18,7 @@ type DocumentEditorProps = {
   onSelectionChange: (payload: SelectionPayload) => void;
   onEditorReady: (editor: Editor | null) => void;
   onAiCommand?: () => void;
+  onDiffSegmentClick?: (segmentId: string) => void;
 };
 
 function resolveSelectedSegmentId(editor: Editor): string | null {
@@ -32,6 +33,7 @@ export function DocumentEditor({
   onSelectionChange,
   onEditorReady,
   onAiCommand,
+  onDiffSegmentClick,
 }: DocumentEditorProps) {
   const editor = useEditor({
     immediatelyRender: false,
@@ -69,7 +71,18 @@ export function DocumentEditor({
   }, [content, editor]);
 
   return (
-    <div className="document-editor-wrap">
+    <div
+      className="document-editor-wrap"
+      onClick={(e) => {
+        if (!onDiffSegmentClick) return;
+        const target = (e.target as HTMLElement).closest("[data-diff-segment]");
+        if (!target) return;
+        const segmentId = target.getAttribute("data-diff-segment");
+        if (segmentId) {
+          onDiffSegmentClick(segmentId);
+        }
+      }}
+    >
       <EditorContent editor={editor} className="document-editor" />
     </div>
   );

--- a/src/components/editor/EditorLayout.module.css
+++ b/src/components/editor/EditorLayout.module.css
@@ -1,0 +1,29 @@
+/* HWP-like editor canvas: gray background, A4 paper centered */
+.canvas {
+  background: #d1d1d1;
+  min-height: 100%;
+  overflow-y: auto;
+  padding: 24px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* A4 paper: 210mm × 297mm ≈ 794px × 1123px at 96 dpi */
+.paper {
+  width: 794px;
+  min-height: 1123px;
+  background: #ffffff;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.18),
+    0 4px 16px rgba(0, 0, 0, 0.13);
+  margin-bottom: 24px;
+  position: relative;
+}
+
+@media (max-width: 860px) {
+  .paper {
+    width: 100%;
+    min-height: auto;
+  }
+}

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type { ReactNode } from "react";
+import styles from "./EditorLayout.module.css";
+
+type EditorLayoutProps = {
+  children: ReactNode;
+};
+
+/**
+ * Wraps the document editor in an HWP-like canvas:
+ * gray background + centered A4 white paper with shadow.
+ */
+export function EditorLayout({ children }: EditorLayoutProps) {
+  return (
+    <div className={styles.canvas}>
+      <div className={styles.paper}>{children}</div>
+    </div>
+  );
+}

--- a/src/components/editor/EditorRuler.module.css
+++ b/src/components/editor/EditorRuler.module.css
@@ -1,0 +1,53 @@
+/* Ruler sits above the A4 paper, aligned to its left edge */
+.rulerWrap {
+  width: 794px;
+  background: #e8e8e8;
+  border-bottom: 1px solid #b8b8b8;
+  height: 18px;
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.ruler {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+}
+
+.tickMinor,
+.tickMajor {
+  position: absolute;
+  bottom: 0;
+  width: 1px;
+  background: #888;
+}
+
+.tickMinor {
+  height: 4px;
+}
+
+.tickMajor {
+  height: 8px;
+  background: #444;
+}
+
+.label {
+  position: absolute;
+  bottom: 9px;
+  left: 2px;
+  font-size: 8px;
+  color: #444;
+  font-family: '맑은 고딕', 'Malgun Gothic', sans-serif;
+  white-space: nowrap;
+  line-height: 1;
+  pointer-events: none;
+}
+
+@media (max-width: 860px) {
+  .rulerWrap {
+    width: 100%;
+  }
+}

--- a/src/components/editor/EditorRuler.tsx
+++ b/src/components/editor/EditorRuler.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import styles from "./EditorRuler.module.css";
+
+/**
+ * Horizontal ruler that matches the A4 paper width (794px content area).
+ * Tick marks every 10mm; numbers at 20mm, 40mm, … in centimeters.
+ * A4 printable width ≈ 180mm (with 15mm margins each side).
+ */
+const PAPER_WIDTH_MM = 190; // full printable span shown in ruler
+const MM_PER_TICK = 5;
+const PX_PER_MM = 794 / 210; // A4 = 210mm wide
+
+export function EditorRuler() {
+  const ticks: { mm: number; major: boolean }[] = [];
+  for (let mm = 0; mm <= PAPER_WIDTH_MM; mm += MM_PER_TICK) {
+    ticks.push({ mm, major: mm % 10 === 0 });
+  }
+
+  return (
+    <div className={styles.rulerWrap}>
+      <div className={styles.ruler}>
+        {ticks.map(({ mm, major }) => (
+          <span
+            key={mm}
+            className={major ? styles.tickMajor : styles.tickMinor}
+            style={{ left: `${mm * PX_PER_MM}px` }}
+          >
+            {major && mm > 0 ? <span className={styles.label}>{mm / 10}</span> : null}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/EditorToolbar.module.css
+++ b/src/components/editor/EditorToolbar.module.css
@@ -1,0 +1,129 @@
+/* HWP-like toolbar: dense, flat, desktop-app feel */
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+  padding: 3px 6px;
+  background: #f0f0f0;
+  border-bottom: 1px solid #c0c0c0;
+  border-top: 1px solid #c0c0c0;
+  min-height: 36px;
+  user-select: none;
+}
+
+/* Visual separator between groups */
+.sep {
+  width: 1px;
+  height: 22px;
+  background: #b8b8b8;
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+}
+
+/* Toolbar button */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 26px;
+  padding: 0 5px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
+  font-size: 12px;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  color: #1a1a1a;
+  transition: background 0.08s, border-color 0.08s;
+}
+
+.btn:hover:not(:disabled) {
+  background: #d8e8f8;
+  border-color: #90b4d4;
+}
+
+.btn:active:not(:disabled) {
+  background: #c0d8f0;
+  border-color: #6090c0;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btnActive {
+  background: #d0e4f8 !important;
+  border-color: #5590c8 !important;
+}
+
+/* Font family dropdown */
+.fontSelect {
+  height: 24px;
+  width: 120px;
+  font-size: 12px;
+  font-family: '맑은 고딕', 'Malgun Gothic', sans-serif;
+  border: 1px solid #b4b4b4;
+  border-radius: 2px;
+  background: #fff;
+  padding: 0 2px;
+  cursor: pointer;
+}
+
+.fontSelect:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Font size dropdown */
+.sizeSelect {
+  height: 24px;
+  width: 52px;
+  font-size: 12px;
+  font-family: '맑은 고딕', 'Malgun Gothic', sans-serif;
+  border: 1px solid #b4b4b4;
+  border-radius: 2px;
+  background: #fff;
+  padding: 0 2px;
+  cursor: pointer;
+}
+
+.sizeSelect:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Download link next to export button */
+.downloadLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 26px;
+  font-size: 14px;
+  color: #0369a1;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.downloadLink:hover {
+  color: #0284c7;
+  text-decoration: underline;
+}
+
+/* Panel toggle buttons pushed to the right */
+.panelToggles {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  margin-left: auto;
+}

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -1,71 +1,457 @@
 "use client";
 
+import { useRef, useState } from "react";
 import type { Editor } from "@tiptap/core";
+import type { SidebarTab } from "@/store/document-store";
 import { TableControls } from "./TableControls";
+import { ParagraphStyleModal } from "./ParagraphStyleModal";
+import { CharStyleModal } from "./CharStyleModal";
+import styles from "./EditorToolbar.module.css";
+
+const HWP_FONTS = [
+  "바탕",
+  "바탕체",
+  "궁서",
+  "궁서체",
+  "굴림",
+  "굴림체",
+  "돋움",
+  "돋움체",
+  "맑은 고딕",
+  "나눔고딕",
+  "나눔명조",
+  "Arial",
+  "Times New Roman",
+];
+
+const FONT_SIZES = [8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32, 36, 40, 48, 54, 60, 72];
 
 type EditorToolbarProps = {
   editor: Editor | null;
   sidebarCollapsed: boolean;
+  activeSidebarTab: SidebarTab;
+  disabled: boolean;
+  hasDocument: boolean;
+  downloadUrl: string;
+  downloadName: string;
   onToggleSidebar: () => void;
+  onSetSidebarTab: (tab: SidebarTab) => void;
   onAiCommand: () => void;
+  onPickFile: (file: File) => void;
+  onExport: () => void;
+  onExportPdf: () => void;
+  onExportDocx: () => void;
+  onSave: () => void;
 };
+
+function getCurrentFontFamily(editor: Editor | null): string {
+  if (!editor) return "바탕";
+  const attrs = editor.getAttributes("textStyle") as { fontFamily?: string };
+  return attrs.fontFamily || "바탕";
+}
+
+function getCurrentFontSize(editor: Editor | null): number {
+  if (!editor) return 10;
+  const attrs = editor.getAttributes("textStyle") as { fontSize?: string };
+  const raw = attrs.fontSize || "";
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 10;
+}
+
+function getCurrentLetterSpacing(editor: Editor | null): number {
+  if (!editor) {
+    return 0;
+  }
+  const paragraphAttrs = editor.getAttributes("paragraph") as { letterSpacing?: number | string };
+  const headingAttrs = editor.getAttributes("heading") as { letterSpacing?: number | string };
+  const raw = paragraphAttrs.letterSpacing ?? headingAttrs.letterSpacing;
+  const parsed = Number.parseInt(String(raw ?? 0), 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
 
 export function EditorToolbar({
   editor,
   sidebarCollapsed,
+  activeSidebarTab,
+  disabled: globalDisabled,
+  hasDocument,
+  downloadUrl,
+  downloadName,
   onToggleSidebar,
+  onSetSidebarTab,
   onAiCommand,
+  onPickFile,
+  onExport,
+  onExportPdf,
+  onExportDocx,
+  onSave,
 }: EditorToolbarProps) {
-  const disabled = !editor;
+  const editorDisabled = !editor;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [paraModalOpen, setParaModalOpen] = useState(false);
+  const [charModalOpen, setCharModalOpen] = useState(false);
+
+  const currentFont = getCurrentFontFamily(editor);
+  const currentSize = getCurrentFontSize(editor);
+  const currentLetterSpacing = getCurrentLetterSpacing(editor);
+
+  const isTabActive = (tab: SidebarTab) => !sidebarCollapsed && activeSidebarTab === tab;
+
+  const updateLetterSpacing = (delta: number) => {
+    if (!editor) {
+      return;
+    }
+    const next = Math.max(-50, Math.min(50, currentLetterSpacing + delta));
+    const attrs = { letterSpacing: next };
+    if (editor.isActive("heading")) {
+      editor.chain().focus().updateAttributes("heading", attrs).run();
+      return;
+    }
+    editor.chain().focus().updateAttributes("paragraph", attrs).run();
+  };
 
   return (
-    <div className="editor-toolbar">
-      <div className="toolbar-group">
-        <button
-          type="button"
-          className={editor?.isActive("bold") ? "toolbar-btn active" : "toolbar-btn"}
-          disabled={disabled}
-          onClick={() => editor?.chain().focus().toggleBold().run()}
-        >
-          Bold
-        </button>
-        <button
-          type="button"
-          className={editor?.isActive("italic") ? "toolbar-btn active" : "toolbar-btn"}
-          disabled={disabled}
-          onClick={() => editor?.chain().focus().toggleItalic().run()}
-        >
-          Italic
-        </button>
-        <button
-          type="button"
-          className="toolbar-btn"
-          disabled={disabled}
-          onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()}
-        >
-          H2
-        </button>
+    <>
+      <div className={styles.toolbar}>
+        {/* ── 파일 열기/내보내기 ── */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".hwpx,.docx,.pptx"
+          style={{ display: "none" }}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) onPickFile(file);
+            e.target.value = "";
+          }}
+        />
+        <div className={styles.group}>
+          <button
+            type="button"
+            className={styles.btn}
+            disabled={globalDisabled}
+            onClick={() => fileInputRef.current?.click()}
+            title="열기"
+          >
+            열기
+          </button>
+          <button
+            type="button"
+            className={styles.btn}
+            disabled={globalDisabled || !hasDocument}
+            onClick={onExport}
+            title="내보내기"
+          >
+            내보내기
+          </button>
+          <button
+            type="button"
+            className={styles.btn}
+            disabled={globalDisabled || !hasDocument}
+            onClick={onExportPdf}
+            title="PDF 내보내기"
+          >
+            PDF
+          </button>
+          <button
+            type="button"
+            className={styles.btn}
+            disabled={globalDisabled || !hasDocument}
+            onClick={onExportDocx}
+            title="DOCX 내보내기"
+          >
+            DOCX
+          </button>
+          {downloadUrl && (
+            <a
+              href={downloadUrl}
+              download={downloadName}
+              className={styles.downloadLink}
+              title="다운로드"
+            >
+              ↓
+            </a>
+          )}
+        </div>
+
+        <div className={styles.sep} />
+
+        {/* ── 실행 취소/다시 실행/저장 ── */}
+        <div className={styles.group}>
+          <Btn
+            label="←"
+            title="실행 취소 (Ctrl+Z)"
+            active={false}
+            disabled={editorDisabled || !(editor?.can().undo() ?? false)}
+            onClick={() => editor?.chain().focus().undo().run()}
+          />
+          <Btn
+            label="→"
+            title="다시 실행 (Ctrl+Y)"
+            active={false}
+            disabled={editorDisabled || !(editor?.can().redo() ?? false)}
+            onClick={() => editor?.chain().focus().redo().run()}
+          />
+          <Btn
+            label="저장"
+            title="저장 (Ctrl+S)"
+            active={false}
+            disabled={globalDisabled || !hasDocument}
+            onClick={onSave}
+          />
+        </div>
+
+        <div className={styles.sep} />
+
+        {/* ── 글꼴 ── */}
+        <div className={styles.group}>
+          <select
+            className={styles.fontSelect}
+            disabled={editorDisabled}
+            value={currentFont}
+            onChange={(e) => {
+              editor?.chain().focus().setFontFamily(e.target.value).run();
+            }}
+            title="글꼴"
+          >
+            {HWP_FONTS.map((f) => (
+              <option key={f} value={f} style={{ fontFamily: f }}>
+                {f}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className={styles.sizeSelect}
+            disabled={editorDisabled}
+            value={currentSize}
+            onChange={(e) => {
+              const size = Number(e.target.value);
+              editor?.chain().focus().setMark("textStyle", { fontSize: `${size}pt` }).run();
+            }}
+            title="글자 크기"
+          >
+            {FONT_SIZES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.sep} />
+
+        {/* ── 글자 스타일 ── */}
+        <div className={styles.group}>
+          <Btn
+            label={<b>가</b>}
+            title="굵게 (Ctrl+B)"
+            active={editor?.isActive("bold") ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().toggleBold().run()}
+          />
+          <Btn
+            label={<i>가</i>}
+            title="기울임 (Ctrl+I)"
+            active={editor?.isActive("italic") ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().toggleItalic().run()}
+          />
+          <Btn
+            label={<u>가</u>}
+            title="밑줄 (Ctrl+U)"
+            active={editor?.isActive("underline") ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().toggleUnderline().run()}
+          />
+          <Btn
+            label="가"
+            title="글자 모양 (Alt+L)"
+            active={false}
+            disabled={editorDisabled}
+            onClick={() => setCharModalOpen(true)}
+          />
+          <Btn
+            label="자간-"
+            title="자간 줄이기"
+            active={false}
+            disabled={editorDisabled}
+            onClick={() => updateLetterSpacing(-1)}
+          />
+          <button
+            type="button"
+            className={styles.btn}
+            title="현재 자간"
+            disabled
+            aria-label="현재 자간"
+          >
+            {`자간 ${currentLetterSpacing}`}
+          </button>
+          <Btn
+            label="자간+"
+            title="자간 늘리기"
+            active={false}
+            disabled={editorDisabled}
+            onClick={() => updateLetterSpacing(1)}
+          />
+        </div>
+
+        <div className={styles.sep} />
+
+        {/* ── 문단 정렬 ── */}
+        <div className={styles.group}>
+          <Btn
+            label="≡←"
+            title="왼쪽 정렬 (Ctrl+L)"
+            active={editor?.isActive({ textAlign: "left" }) ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().setTextAlign("left").run()}
+          />
+          <Btn
+            label="≡↔"
+            title="가운데 정렬 (Ctrl+E)"
+            active={editor?.isActive({ textAlign: "center" }) ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().setTextAlign("center").run()}
+          />
+          <Btn
+            label="≡→"
+            title="오른쪽 정렬 (Ctrl+R)"
+            active={editor?.isActive({ textAlign: "right" }) ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().setTextAlign("right").run()}
+          />
+          <Btn
+            label="≡≡"
+            title="양쪽 정렬 (Ctrl+J)"
+            active={editor?.isActive({ textAlign: "justify" }) ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().setTextAlign("justify").run()}
+          />
+          <Btn
+            label="문단"
+            title="문단 모양 (Alt+T)"
+            active={false}
+            disabled={editorDisabled}
+            onClick={() => setParaModalOpen(true)}
+          />
+        </div>
+
+        <div className={styles.sep} />
+
+        {/* ── 제목 ── */}
+        <div className={styles.group}>
+          <Btn
+            label="H1"
+            title="제목 1"
+            active={editor?.isActive("heading", { level: 1 }) ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().toggleHeading({ level: 1 }).run()}
+          />
+          <Btn
+            label="H2"
+            title="제목 2"
+            active={editor?.isActive("heading", { level: 2 }) ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()}
+          />
+          <Btn
+            label="H3"
+            title="제목 3"
+            active={editor?.isActive("heading", { level: 3 }) ?? false}
+            disabled={editorDisabled}
+            onClick={() => editor?.chain().focus().toggleHeading({ level: 3 }).run()}
+          />
+        </div>
+
+        <div className={styles.sep} />
+
+        {/* ── 표 ── */}
+        <TableControls editor={editor} />
+
+        <div className={styles.sep} />
+
+        {/* ── AI ── */}
+        <div className={styles.group}>
+          <button type="button" className={styles.btn} disabled={editorDisabled} onClick={onAiCommand}>
+            AI 수정
+          </button>
+        </div>
+
+        {/* ── 우측 패널 토글 (flex push) ── */}
+        <div className={styles.panelToggles}>
+          <Btn
+            label="개요"
+            title="문서 개요"
+            active={isTabActive("outline")}
+            disabled={false}
+            onClick={() => onSetSidebarTab("outline")}
+          />
+          <Btn
+            label="AI"
+            title="AI 제안"
+            active={isTabActive("ai")}
+            disabled={false}
+            onClick={() => onSetSidebarTab("ai")}
+          />
+          <Btn
+            label="채팅"
+            title="AI 채팅"
+            active={isTabActive("chat")}
+            disabled={false}
+            onClick={() => onSetSidebarTab("chat")}
+          />
+          <Btn
+            label="분석"
+            title="문서 분석"
+            active={isTabActive("analysis")}
+            disabled={false}
+            onClick={() => onSetSidebarTab("analysis")}
+          />
+          <Btn
+            label="이력"
+            title="수정 이력"
+            active={isTabActive("history")}
+            disabled={false}
+            onClick={() => onSetSidebarTab("history")}
+          />
+        </div>
       </div>
 
-      <TableControls editor={editor} />
-
-      <div className="toolbar-group">
-        <button type="button" className="toolbar-btn" disabled={disabled} onClick={onAiCommand}>
-          AI 수정
-        </button>
-        <button
-          type="button"
-          className="toolbar-btn"
-          disabled={disabled}
-          onClick={() => editor?.chain().focus().insertContent("#").run()}
-        >
-          # 명령어
-        </button>
-        <button type="button" className="toolbar-btn" onClick={onToggleSidebar}>
-          {sidebarCollapsed ? "사이드바 열기" : "사이드바 닫기"}
-        </button>
-      </div>
-    </div>
+      {paraModalOpen && editor && (
+        <ParagraphStyleModal editor={editor} onClose={() => setParaModalOpen(false)} />
+      )}
+      {charModalOpen && editor && (
+        <CharStyleModal editor={editor} onClose={() => setCharModalOpen(false)} />
+      )}
+    </>
   );
 }
 
+/* ── Small helpers ── */
+
+function Btn({
+  label,
+  title,
+  active,
+  disabled,
+  onClick,
+}: {
+  label: React.ReactNode;
+  title: string;
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={active ? `${styles.btn} ${styles.btnActive}` : styles.btn}
+      title={title}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/editor/ParagraphStyleModal.tsx
+++ b/src/components/editor/ParagraphStyleModal.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import type { Editor } from "@tiptap/core";
+import styles from "./StyleModal.module.css";
+
+type ParagraphStyleModalProps = {
+  editor: Editor;
+  onClose: () => void;
+};
+
+type ParagraphStyleState = {
+  align: "left" | "center" | "right" | "justify";
+  leftIndent: number;   // mm
+  rightIndent: number;  // mm
+  firstLine: number;    // mm (positive = indent, negative = outdent)
+  lineHeight: number;   // % (e.g. 160)
+  spaceBefore: number;  // pt
+  spaceAfter: number;   // pt
+};
+
+/** Read current paragraph attrs from editor selection */
+function readCurrentParaStyle(editor: Editor): ParagraphStyleState {
+  const attrs = editor.getAttributes("paragraph") as {
+    textAlign?: string;
+    style?: string;
+  };
+  const align = (attrs.textAlign ?? "left") as ParagraphStyleState["align"];
+
+  // Parse inline style for spacing hints (best-effort)
+  const style = attrs.style ?? "";
+  const parse = (prop: string, defaultVal: number) => {
+    const m = style.match(new RegExp(`${prop}:\\s*([\\d.]+)`));
+    return m ? Number.parseFloat(m[1]) : defaultVal;
+  };
+
+  return {
+    align,
+    leftIndent: 0,
+    rightIndent: 0,
+    firstLine: 0,
+    lineHeight: parse("line-height", 1.6) * 100,
+    spaceBefore: 0,
+    spaceAfter: parse("margin-bottom", 0) * 0.75, // rough px→pt
+  };
+}
+
+export function ParagraphStyleModal({ editor, onClose }: ParagraphStyleModalProps) {
+  const [state, setState] = useState<ParagraphStyleState>(() => readCurrentParaStyle(editor));
+
+  const update = <K extends keyof ParagraphStyleState>(key: K, value: ParagraphStyleState[K]) => {
+    setState((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const onApply = () => {
+    const chain = editor.chain().focus();
+
+    // Text alignment
+    chain.setTextAlign(state.align);
+
+    // Build inline style
+    const styleTokens: string[] = [];
+    if (state.lineHeight !== 160) {
+      styleTokens.push(`line-height: ${(state.lineHeight / 100).toFixed(2)}`);
+    }
+    if (state.leftIndent) {
+      styleTokens.push(`margin-left: ${state.leftIndent}mm`);
+    }
+    if (state.rightIndent) {
+      styleTokens.push(`margin-right: ${state.rightIndent}mm`);
+    }
+    if (state.firstLine > 0) {
+      styleTokens.push(`text-indent: ${state.firstLine}mm`);
+    } else if (state.firstLine < 0) {
+      styleTokens.push(`margin-left: ${Math.abs(state.firstLine)}mm`);
+      styleTokens.push(`text-indent: ${state.firstLine}mm`);
+    }
+    if (state.spaceBefore) {
+      styleTokens.push(`margin-top: ${(state.spaceBefore / 0.75).toFixed(1)}px`);
+    }
+    if (state.spaceAfter) {
+      styleTokens.push(`margin-bottom: ${(state.spaceAfter / 0.75).toFixed(1)}px`);
+    }
+
+    if (styleTokens.length) {
+      chain.updateAttributes("paragraph", { style: styleTokens.join("; ") });
+    }
+    chain.run();
+    onClose();
+  };
+
+  return (
+    <div className={styles.backdrop} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.titleBar}>
+          <span>문단 모양</span>
+          <button type="button" className={styles.closeBtn} onClick={onClose}>✕</button>
+        </div>
+
+        <div className={styles.body}>
+          {/* ── 정렬 ── */}
+          <fieldset className={styles.fieldset}>
+            <legend>정렬</legend>
+            <div className={styles.row}>
+              {(["left", "center", "right", "justify"] as const).map((a) => (
+                <button
+                  key={a}
+                  type="button"
+                  className={state.align === a ? `${styles.alignBtn} ${styles.alignBtnActive}` : styles.alignBtn}
+                  onClick={() => update("align", a)}
+                >
+                  {{
+                    left: "왼쪽",
+                    center: "가운데",
+                    right: "오른쪽",
+                    justify: "양쪽",
+                  }[a]}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* ── 여백 ── */}
+          <fieldset className={styles.fieldset}>
+            <legend>여백</legend>
+            <div className={styles.grid2}>
+              <NumField label="왼쪽 (mm)" value={state.leftIndent} step={1} min={0} max={150} onChange={(v) => update("leftIndent", v)} />
+              <NumField label="오른쪽 (mm)" value={state.rightIndent} step={1} min={0} max={150} onChange={(v) => update("rightIndent", v)} />
+              <NumField label="첫 줄 들여쓰기 (mm)" value={state.firstLine} step={1} min={-50} max={50} onChange={(v) => update("firstLine", v)} />
+            </div>
+          </fieldset>
+
+          {/* ── 간격 ── */}
+          <fieldset className={styles.fieldset}>
+            <legend>간격</legend>
+            <div className={styles.grid2}>
+              <NumField label="줄 간격 (%)" value={state.lineHeight} step={5} min={80} max={300} onChange={(v) => update("lineHeight", v)} />
+              <NumField label="문단 위 간격 (pt)" value={state.spaceBefore} step={1} min={0} max={100} onChange={(v) => update("spaceBefore", v)} />
+              <NumField label="문단 아래 간격 (pt)" value={state.spaceAfter} step={1} min={0} max={100} onChange={(v) => update("spaceAfter", v)} />
+            </div>
+          </fieldset>
+        </div>
+
+        <div className={styles.footer}>
+          <button type="button" className={styles.applyBtn} onClick={onApply}>설정</button>
+          <button type="button" className={styles.cancelBtn} onClick={onClose}>취소</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NumField({
+  label,
+  value,
+  step,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  step: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className={styles.numField}>
+      <span className={styles.numLabel}>{label}</span>
+      <input
+        type="number"
+        className={styles.numInput}
+        value={value}
+        step={step}
+        min={min}
+        max={max}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </label>
+  );
+}

--- a/src/components/editor/StyleModal.module.css
+++ b/src/components/editor/StyleModal.module.css
@@ -1,0 +1,229 @@
+/* Shared styles for 글자 모양 / 문단 모양 modals */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #f5f5f5;
+  border: 1px solid #808080;
+  border-radius: 4px;
+  box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.35);
+  width: 420px;
+  max-width: 96vw;
+  display: flex;
+  flex-direction: column;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
+  font-size: 13px;
+  color: #1a1a1a;
+}
+
+/* Title bar mimicking HWP dialog */
+.titleBar {
+  background: linear-gradient(to bottom, #4878b8 0%, #2458a0 100%);
+  color: #fff;
+  padding: 6px 10px;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 4px 4px 0 0;
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.closeBtn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+}
+
+.body {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #f5f5f5;
+}
+
+.fieldset {
+  border: 1px solid #c0c0c0;
+  border-radius: 3px;
+  padding: 8px 10px 10px;
+  margin: 0;
+}
+
+.fieldset legend {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 0 4px;
+  color: #444;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 8px 14px 12px;
+  border-top: 1px solid #d0d0d0;
+  background: #ececec;
+  border-radius: 0 0 4px 4px;
+}
+
+.applyBtn,
+.cancelBtn {
+  padding: 4px 18px;
+  font-size: 12px;
+  font-family: inherit;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.applyBtn {
+  background: #2458a0;
+  color: #fff;
+  border: 1px solid #1a4080;
+}
+
+.applyBtn:hover {
+  background: #1a4080;
+}
+
+.cancelBtn {
+  background: #f0f0f0;
+  color: #333;
+  border: 1px solid #aaa;
+}
+
+.cancelBtn:hover {
+  background: #e0e0e0;
+}
+
+/* ── Alignment buttons ── */
+.row {
+  display: flex;
+  gap: 4px;
+}
+
+.alignBtn {
+  flex: 1;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+  border: 1px solid #b0b0b0;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.alignBtn:hover {
+  background: #dceaf8;
+  border-color: #90b4d4;
+}
+
+.alignBtnActive {
+  background: #c8dff0 !important;
+  border-color: #5590c8 !important;
+  font-weight: 600;
+}
+
+/* ── Number / Select fields ── */
+.grid2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.numField {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.numLabel {
+  font-size: 11px;
+  color: #555;
+}
+
+.numInput {
+  width: 100%;
+  height: 24px;
+  border: 1px solid #b4b4b4;
+  border-radius: 2px;
+  padding: 0 4px;
+  font-size: 12px;
+  font-family: inherit;
+  background: #fff;
+}
+
+.select {
+  width: 100%;
+  height: 24px;
+  border: 1px solid #b4b4b4;
+  border-radius: 2px;
+  padding: 0 2px;
+  font-size: 12px;
+  font-family: inherit;
+  background: #fff;
+}
+
+/* ── Checkbox row ── */
+.checkRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.checkLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+/* ── Color row ── */
+.colorRow {
+  display: flex;
+  gap: 16px;
+}
+
+.colorField {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.colorField input[type="color"] {
+  width: 32px;
+  height: 24px;
+  border: 1px solid #b4b4b4;
+  border-radius: 2px;
+  padding: 0;
+  cursor: pointer;
+}
+
+/* ── Preview box ── */
+.preview {
+  min-height: 40px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  padding: 8px 10px;
+  font-size: 14px;
+  line-height: 1.6;
+}

--- a/src/components/sidebar/AiSuggestionPanel.tsx
+++ b/src/components/sidebar/AiSuggestionPanel.tsx
@@ -1,5 +1,35 @@
 "use client";
 
+import { useMemo } from "react";
+import { diffWords } from "diff";
+import type { InstructionPreset, PresetKey } from "@/lib/editor/ai-presets";
+import type { VerificationResult } from "@/store/document-store";
+
+function InlineDiff({ before, after }: { before: string; after: string }) {
+  const changes = diffWords(before, after);
+  return (
+    <p style={{ fontSize: 11, lineHeight: 1.4, whiteSpace: "pre-wrap" }}>
+      {changes.map((change, i) => {
+        if (change.removed) {
+          return (
+            <span key={`d-${i}`} className="diff-text-removed">
+              {change.value}
+            </span>
+          );
+        }
+        if (change.added) {
+          return (
+            <span key={`d-${i}`} className="diff-text-added">
+              {change.value}
+            </span>
+          );
+        }
+        return <span key={`d-${i}`}>{change.value}</span>;
+      })}
+    </p>
+  );
+}
+
 type AiSuggestionPanelProps = {
   instruction: string;
   suggestion: string;
@@ -13,6 +43,21 @@ type AiSuggestionPanelProps = {
   onApplySuggestion: () => void;
   onRequestBatchSuggestion: () => void;
   onApplyBatchSuggestion: () => void;
+  // Phase 2-1: Accept/Reject
+  batchDecisions: Record<string, "accepted" | "rejected">;
+  onSetBatchDecision: (id: string, decision: "accepted" | "rejected") => void;
+  onApplySelectedBatchSuggestion: () => void;
+  // Phase 2-3: Presets
+  presets: InstructionPreset[];
+  selectedPreset: PresetKey;
+  onSelectPreset: (key: PresetKey) => void;
+  // Phase 2-6: Verification
+  verificationResult: VerificationResult | null;
+  verificationLoading: boolean;
+  onVerifySuggestion: () => void;
+  // Batch mode
+  batchMode: "section" | "document";
+  onSetBatchMode: (mode: "section" | "document") => void;
 };
 
 export function AiSuggestionPanel({
@@ -28,11 +73,57 @@ export function AiSuggestionPanel({
   onApplySuggestion,
   onRequestBatchSuggestion,
   onApplyBatchSuggestion,
+  batchDecisions,
+  onSetBatchDecision,
+  onApplySelectedBatchSuggestion,
+  presets,
+  selectedPreset,
+  onSelectPreset,
+  verificationResult,
+  verificationLoading,
+  onVerifySuggestion,
+  batchMode,
+  onSetBatchMode,
 }: AiSuggestionPanelProps) {
+  const { acceptedCount, rejectedCount } = useMemo(() => {
+    const ids = new Set(batchDiffItems.map((d) => d.id));
+    let accepted = 0;
+    let rejected = 0;
+    for (const [id, decision] of Object.entries(batchDecisions)) {
+      if (!ids.has(id)) continue;
+      if (decision === "accepted") accepted++;
+      else if (decision === "rejected") rejected++;
+    }
+    return { acceptedCount: accepted, rejectedCount: rejected };
+  }, [batchDecisions, batchDiffItems]);
+
   return (
     <div className="ai-panel">
+      {/* ── 선택 텍스트 ── */}
       <label className="sidebar-label">선택 텍스트</label>
       <div className="sidebar-box">{selectedText || "에디터에서 텍스트를 선택하세요."}</div>
+
+      {/* ── 프리셋 + 지시문 ── */}
+      <label className="sidebar-label">지시문 프리셋</label>
+      <select
+        className="sidebar-textarea"
+        style={{ minHeight: "auto", height: 26, resize: "none", padding: "0 6px" }}
+        value={selectedPreset}
+        onChange={(e) => {
+          const key = e.target.value as PresetKey;
+          onSelectPreset(key);
+          const preset = presets.find((p) => p.key === key);
+          if (preset && preset.instruction) {
+            onChangeInstruction(preset.instruction);
+          }
+        }}
+      >
+        {presets.map((p) => (
+          <option key={p.key} value={p.key}>
+            {p.label}
+          </option>
+        ))}
+      </select>
 
       <label className="sidebar-label">AI 지시문</label>
       <textarea
@@ -41,6 +132,7 @@ export function AiSuggestionPanel({
         onChange={(event) => onChangeInstruction(event.target.value)}
       />
 
+      {/* ── 단일 제안 ── */}
       <div className="sidebar-actions">
         <button type="button" className="btn" disabled={isBusy} onClick={onRequestSuggestion}>
           AI 제안 생성
@@ -48,12 +140,68 @@ export function AiSuggestionPanel({
         <button type="button" className="btn" disabled={isBusy || !suggestion} onClick={onApplySuggestion}>
           제안 적용
         </button>
+        <button
+          type="button"
+          className="btn"
+          disabled={isBusy || !suggestion || verificationLoading}
+          onClick={onVerifySuggestion}
+          title="AI 수정 검증"
+        >
+          {verificationLoading ? "검증 중..." : "검증"}
+        </button>
       </div>
+
+      {/* Verification result */}
+      {verificationResult && (
+        <div
+          style={{
+            padding: "4px 8px",
+            fontSize: 12,
+            borderRadius: 2,
+            border: verificationResult.passed ? "1px solid #86efac" : "1px solid #fcd34d",
+            background: verificationResult.passed ? "#dcfce7" : "#fffbeb",
+            color: verificationResult.passed ? "#166534" : "#7c4a03",
+          }}
+        >
+          {verificationResult.passed ? (
+            <span>&#10003; 검증 통과</span>
+          ) : (
+            <div>
+              <div style={{ fontWeight: 600, marginBottom: 2 }}>&#9888; 검증 이슈</div>
+              {verificationResult.issues.map((issue, i) => (
+                <div key={`vr-${i}`} style={{ paddingLeft: 8, marginTop: 2 }}>
+                  - {issue}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       <label className="sidebar-label">AI 제안 결과</label>
       <div className="sidebar-box">{suggestion || "아직 제안이 없습니다."}</div>
 
-      <label className="sidebar-label">섹션 일괄 수정</label>
+      {/* ── 일괄 수정 범위 ── */}
+      <label className="sidebar-label">일괄 수정 범위</label>
+      <div className="sidebar-actions">
+        <button
+          type="button"
+          className={`btn ${batchMode === "section" ? "primary" : ""}`}
+          onClick={() => onSetBatchMode("section")}
+        >
+          섹션
+        </button>
+        <button
+          type="button"
+          className={`btn ${batchMode === "document" ? "primary" : ""}`}
+          onClick={() => onSetBatchMode("document")}
+        >
+          전체 문서
+        </button>
+      </div>
+
+      {/* ── 일괄 수정 ── */}
+      <label className="sidebar-label">일괄 수정</label>
       <div className="sidebar-box">
         현재 대상 {batchTargetCount}개 / 생성된 제안 {batchSuggestionCount}개
       </div>
@@ -64,7 +212,7 @@ export function AiSuggestionPanel({
           disabled={isBusy || batchTargetCount === 0}
           onClick={onRequestBatchSuggestion}
         >
-          섹션 일괄 제안 생성
+          일괄 제안 생성
         </button>
         <button
           type="button"
@@ -72,28 +220,63 @@ export function AiSuggestionPanel({
           disabled={isBusy || batchSuggestionCount === 0}
           onClick={onApplyBatchSuggestion}
         >
-          섹션 일괄 적용
+          전체 적용
         </button>
       </div>
+
+      {/* ── Accept/Reject individual diffs ── */}
+      {acceptedCount + rejectedCount > 0 && (
+        <div className="sidebar-actions">
+          <button
+            type="button"
+            className="btn"
+            disabled={isBusy || acceptedCount === 0}
+            onClick={onApplySelectedBatchSuggestion}
+          >
+            선택 적용 ({acceptedCount}건 수락 / {rejectedCount}건 거부)
+          </button>
+        </div>
+      )}
 
       <label className="sidebar-label">일괄 제안 Diff</label>
       {batchDiffItems.length ? (
         <ul className="batch-diff-list">
-          {batchDiffItems.map((item) => (
-            <li key={item.id} className="batch-diff-item">
-              <strong>{item.id}</strong>
-              <div className="batch-diff-grid">
-                <div className="batch-diff-col">
-                  <small>Before</small>
-                  <p>{item.before}</p>
+          {batchDiffItems.map((item) => {
+            const decision = batchDecisions[item.id];
+            return (
+              <li
+                key={item.id}
+                className="batch-diff-item"
+                data-batch-diff-id={item.id}
+                style={decision === "rejected" ? { opacity: 0.5 } : undefined}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                  <strong style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {item.id}
+                  </strong>
+                  <button
+                    type="button"
+                    className="batch-decision-btn"
+                    data-state={decision === "accepted" ? "accepted" : undefined}
+                    onClick={() => onSetBatchDecision(item.id, "accepted")}
+                    title="수락"
+                  >
+                    &#10003;
+                  </button>
+                  <button
+                    type="button"
+                    className="batch-decision-btn"
+                    data-state={decision === "rejected" ? "rejected" : undefined}
+                    onClick={() => onSetBatchDecision(item.id, "rejected")}
+                    title="거부"
+                  >
+                    &#10007;
+                  </button>
                 </div>
-                <div className="batch-diff-col">
-                  <small>After</small>
-                  <p>{item.after}</p>
-                </div>
-              </div>
-            </li>
-          ))}
+                <InlineDiff before={item.before} after={item.after} />
+              </li>
+            );
+          })}
         </ul>
       ) : (
         <div className="sidebar-box">변경된 일괄 제안이 없습니다.</div>

--- a/src/components/sidebar/ChatPanel.tsx
+++ b/src/components/sidebar/ChatPanel.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState, useRef, useEffect, useMemo } from "react";
+import { diffWords } from "diff";
+import type { ChatMessageUI, PendingToolCall, EditPreviewItem } from "@/types/chat";
+import { INSTRUCTION_PRESETS } from "@/lib/editor/ai-presets";
+
+type ChatPanelProps = {
+  messages: ChatMessageUI[];
+  isBusy: boolean;
+  pendingToolCall: PendingToolCall | null;
+  hasDocument: boolean;
+  onSendMessage: (text: string) => void;
+  onApproveTool: () => void;
+  onRejectTool: () => void;
+  onClearChat: () => void;
+};
+
+const QUICK_COMMANDS = INSTRUCTION_PRESETS
+  .filter((p) => p.key !== "custom" && p.key !== "yearly_update")
+  .map((p) => ({
+    label: p.label,
+    message: `전체 문서를 다음과 같이 수정해줘: ${p.instruction}`,
+  }));
+
+export function ChatPanel({
+  messages,
+  isBusy,
+  pendingToolCall,
+  hasDocument,
+  onSendMessage,
+  onApproveTool,
+  onRejectTool,
+  onClearChat,
+}: ChatPanelProps) {
+  const [input, setInput] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, pendingToolCall]);
+
+  const handleSubmit = () => {
+    const trimmed = input.trim();
+    if (!trimmed || isBusy) return;
+    onSendMessage(trimmed);
+    setInput("");
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const handleTextareaInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value);
+    // Auto-resize
+    const el = e.target;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 120) + "px";
+  };
+
+  return (
+    <div className="chat-panel">
+      {/* Message list */}
+      <div className="chat-messages">
+        {messages.length === 0 && !isBusy && (
+          <div className="chat-empty">
+            <p style={{ fontSize: 13, color: "#6b7280", textAlign: "center", padding: "20px 0" }}>
+              {hasDocument
+                ? "문서에 대해 자유롭게 지시하세요.\n예: \"전체 톤을 공문서체로 바꿔줘\""
+                : "먼저 문서를 업로드하세요."}
+            </p>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <ChatMessage key={msg.id} message={msg} />
+        ))}
+
+        {/* Pending tool approval */}
+        {pendingToolCall && (
+          <div className="chat-pending-tool">
+            <div className="chat-pending-tool-header">
+              <span className="chat-tool-badge">편집 승인 대기</span>
+              <span className="chat-tool-name">{pendingToolCall.toolCall.name}</span>
+            </div>
+            {pendingToolCall.preview && (
+              <div className="chat-pending-tool-preview">
+                <p className="chat-tool-summary">{pendingToolCall.preview.summary}</p>
+                <div className="chat-tool-diffs">
+                  {pendingToolCall.preview.edits.slice(0, 5).map((edit, i) => (
+                    <EditDiffItem key={i} edit={edit} />
+                  ))}
+                  {pendingToolCall.preview.edits.length > 5 && (
+                    <p style={{ fontSize: 11, color: "#6b7280", padding: "4px 8px" }}>
+                      ... 외 {pendingToolCall.preview.edits.length - 5}건
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="chat-pending-tool-actions">
+              <button className="btn primary" onClick={onApproveTool} disabled={isBusy}>
+                수락
+              </button>
+              <button className="btn" onClick={onRejectTool} disabled={isBusy}>
+                거부
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Quick commands */}
+      {messages.length === 0 && hasDocument && (
+        <div className="chat-quick-commands">
+          {QUICK_COMMANDS.map((cmd) => (
+            <button
+              key={cmd.label}
+              className="chat-quick-chip"
+              onClick={() => onSendMessage(cmd.message)}
+              disabled={isBusy}
+            >
+              {cmd.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Input area */}
+      <div className="chat-input-area">
+        <div className="chat-input-row">
+          <textarea
+            ref={textareaRef}
+            className="chat-textarea"
+            value={input}
+            onChange={handleTextareaInput}
+            onKeyDown={handleKeyDown}
+            placeholder={hasDocument ? "메시지를 입력하세요..." : "문서를 먼저 업로드하세요"}
+            disabled={isBusy || !hasDocument}
+            rows={1}
+          />
+          <button
+            className="chat-send-btn"
+            onClick={handleSubmit}
+            disabled={!input.trim() || isBusy || !hasDocument}
+          >
+            전송
+          </button>
+        </div>
+        {messages.length > 0 && (
+          <button
+            className="chat-clear-btn"
+            onClick={onClearChat}
+            disabled={isBusy}
+          >
+            대화 초기화
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChatMessage({ message }: { message: ChatMessageUI }) {
+  const isUser = message.role === "user";
+
+  return (
+    <div className={`chat-msg ${isUser ? "chat-msg-user" : "chat-msg-assistant"}`}>
+      <div className={`chat-bubble ${isUser ? "chat-bubble-user" : "chat-bubble-assistant"}`}>
+        <p className="chat-bubble-text">{message.content}</p>
+        {message.isStreaming && !message.content && (
+          <span className="chat-typing">...</span>
+        )}
+      </div>
+      {/* Tool calls display */}
+      {message.toolCalls && message.toolCalls.length > 0 && (
+        <div className="chat-tool-calls">
+          {message.toolCalls.map((tc) => (
+            <ToolCallBadge key={tc.id} name={tc.name} isAutoExecuted={
+              message.toolResults?.some((tr) => tr.toolCallId === tc.id && tr.isAutoExecuted) ?? false
+            } />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolCallBadge({ name, isAutoExecuted }: { name: string; isAutoExecuted: boolean }) {
+  const TOOL_LABELS: Record<string, string> = {
+    read_document: "문서 읽기",
+    read_segment: "세그먼트 읽기",
+    edit_segment: "세그먼트 수정",
+    edit_segments: "일괄 수정",
+    search_replace: "찾아 바꾸기",
+    analyze_style: "스타일 분석",
+  };
+
+  return (
+    <span className={`chat-tool-badge ${isAutoExecuted ? "auto" : "manual"}`}>
+      {isAutoExecuted ? "✓" : "⏳"} {TOOL_LABELS[name] || name}
+    </span>
+  );
+}
+
+function EditDiffItem({ edit }: { edit: EditPreviewItem }) {
+  const changes = useMemo(() => diffWords(edit.before, edit.after), [edit.before, edit.after]);
+
+  return (
+    <div className="chat-diff-item">
+      <p style={{ fontSize: 11, lineHeight: 1.5, whiteSpace: "pre-wrap" }}>
+        {changes.map((change, i) => {
+          if (change.removed) {
+            return (
+              <span key={`d-${i}`} className="diff-text-removed">
+                {change.value}
+              </span>
+            );
+          }
+          if (change.added) {
+            return (
+              <span key={`d-${i}`} className="diff-text-added">
+                {change.value}
+              </span>
+            );
+          }
+          return <span key={`d-${i}`}>{change.value}</span>;
+        })}
+      </p>
+    </div>
+  );
+}

--- a/src/components/sidebar/DocumentAnalysisPanel.tsx
+++ b/src/components/sidebar/DocumentAnalysisPanel.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import type { DocumentAnalysis } from "@/store/document-store";
+
+type DocumentAnalysisPanelProps = {
+  analysis: DocumentAnalysis | null;
+  isLoading: boolean;
+  terminologyDict: Record<string, string>;
+  onUpdateEntry: (variant: string, canonical: string) => void;
+  onRemoveEntry: (variant: string) => void;
+  onApplyTerminology: () => void;
+  isBusy: boolean;
+};
+
+function ScoreBar({ score }: { score: number }) {
+  const color = score >= 70 ? "#22c55e" : score >= 40 ? "#eab308" : "#ef4444";
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <div
+        style={{
+          flex: 1,
+          height: 8,
+          background: "#e2e8f0",
+          borderRadius: 4,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${Math.min(100, Math.max(0, score))}%`,
+            height: "100%",
+            background: color,
+            borderRadius: 4,
+          }}
+        />
+      </div>
+      <span style={{ fontSize: 12, fontWeight: 600, color, minWidth: 28, textAlign: "right" }}>
+        {score}
+      </span>
+    </div>
+  );
+}
+
+export function DocumentAnalysisPanel({
+  analysis,
+  isLoading,
+  terminologyDict,
+  onUpdateEntry,
+  onRemoveEntry,
+  onApplyTerminology,
+  isBusy,
+}: DocumentAnalysisPanelProps) {
+  const [expandTerms, setExpandTerms] = useState(true);
+
+  if (isLoading) {
+    return <p className="sidebar-empty">문서 분석 중...</p>;
+  }
+
+  if (!analysis) {
+    return <p className="sidebar-empty">문서를 열면 자동으로 분석됩니다.</p>;
+  }
+
+  const dictEntries = Object.entries(terminologyDict);
+
+  return (
+    <div className="ai-panel">
+      {/* Document type */}
+      <div>
+        <label className="sidebar-label">문서 유형</label>
+        <div className="sidebar-box" style={{ fontWeight: 600 }}>
+          {analysis.documentType}
+        </div>
+      </div>
+
+      {/* Readability score */}
+      <div>
+        <label className="sidebar-label">가독성 점수</label>
+        <ScoreBar score={analysis.readabilityScore} />
+      </div>
+
+      {/* Global issues */}
+      {analysis.globalIssues.length > 0 && (
+        <div>
+          <label className="sidebar-label">발견된 이슈</label>
+          <ul style={{ listStyle: "none", display: "grid", gap: 4 }}>
+            {analysis.globalIssues.map((issue, i) => (
+              <li
+                key={`issue-${i}`}
+                style={{
+                  fontSize: 12,
+                  padding: "4px 8px",
+                  background: "#fffbeb",
+                  border: "1px solid #f5d899",
+                  borderRadius: 2,
+                  color: "#7c4a03",
+                }}
+              >
+                {issue}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Inconsistent terms */}
+      {analysis.inconsistentTerms.length > 0 && (
+        <div>
+          <button
+            type="button"
+            className="sidebar-label"
+            onClick={() => setExpandTerms(!expandTerms)}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 0,
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            {expandTerms ? "▾" : "▸"} 용어 불일치 ({analysis.inconsistentTerms.length}건)
+          </button>
+          {expandTerms && (
+            <ul style={{ listStyle: "none", display: "grid", gap: 6, marginTop: 4 }}>
+              {analysis.inconsistentTerms.map((term, i) => (
+                <li
+                  key={`term-${i}`}
+                  style={{
+                    fontSize: 12,
+                    padding: "6px 8px",
+                    background: "#f8fbff",
+                    border: "1px solid #dbe6f1",
+                    borderRadius: 2,
+                  }}
+                >
+                  <div style={{ color: "#64748b", marginBottom: 2 }}>
+                    {term.variants.join(", ")}
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                    <span style={{ fontSize: 11, color: "#888" }}>→</span>
+                    <strong>{term.suggestedTerm}</strong>
+                    {!terminologyDict[term.variants[0]] && (
+                      <button
+                        type="button"
+                        style={{
+                          marginLeft: "auto",
+                          fontSize: 11,
+                          padding: "1px 6px",
+                          border: "1px solid #b4b4b4",
+                          borderRadius: 2,
+                          background: "#f0f0f0",
+                          cursor: "pointer",
+                        }}
+                        onClick={() => {
+                          for (const v of term.variants) {
+                            if (v !== term.suggestedTerm) {
+                              onUpdateEntry(v, term.suggestedTerm);
+                            }
+                          }
+                        }}
+                      >
+                        사전 추가
+                      </button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {/* Terminology dictionary */}
+      {dictEntries.length > 0 && (
+        <div>
+          <label className="sidebar-label">용어 사전 ({dictEntries.length}건)</label>
+          <ul style={{ listStyle: "none", display: "grid", gap: 4 }}>
+            {dictEntries.map(([variant, canonical]) => (
+              <li
+                key={variant}
+                style={{
+                  fontSize: 12,
+                  padding: "3px 8px",
+                  background: "#fff",
+                  border: "1px solid #e2e8f0",
+                  borderRadius: 2,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+              >
+                <span style={{ color: "#ef4444", textDecoration: "line-through" }}>{variant}</span>
+                <span style={{ color: "#888" }}>→</span>
+                <strong>{canonical}</strong>
+                <button
+                  type="button"
+                  style={{
+                    marginLeft: "auto",
+                    fontSize: 10,
+                    padding: "0 4px",
+                    border: "none",
+                    background: "transparent",
+                    cursor: "pointer",
+                    color: "#888",
+                  }}
+                  onClick={() => onRemoveEntry(variant)}
+                  title="삭제"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="sidebar-actions" style={{ marginTop: 6 }}>
+            <button
+              type="button"
+              className="btn"
+              disabled={isBusy || !dictEntries.length}
+              onClick={onApplyTerminology}
+            >
+              일괄 치환 ({dictEntries.length}건)
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/Sidebar.module.css
+++ b/src/components/sidebar/Sidebar.module.css
@@ -1,0 +1,41 @@
+/* HWP-style fixed-width right panel */
+.panel {
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: #f8f8f8;
+  border-left: 1px solid #c0c0c0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.panelTitleBar {
+  height: 28px;
+  background: #e8e8e8;
+  border-bottom: 1px solid #c0c0c0;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #1a1a1a;
+  font-family: '맑은 고딕', 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;
+  flex-shrink: 0;
+}
+
+.panelContent {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px;
+}
+
+.panelContentChat {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -2,22 +2,33 @@
 
 import type { ReactNode } from "react";
 import type { SidebarTab } from "@/store/document-store";
+import styles from "./Sidebar.module.css";
+
+const TAB_LABELS: Record<SidebarTab, string> = {
+  outline: "문서 개요",
+  ai: "AI 제안",
+  chat: "AI 채팅",
+  analysis: "문서 분석",
+  history: "수정 이력",
+};
 
 type SidebarProps = {
   collapsed: boolean;
   activeTab: SidebarTab;
-  onChangeTab: (tab: SidebarTab) => void;
   outline: ReactNode;
   ai: ReactNode;
+  chat: ReactNode;
+  analysis: ReactNode;
   history: ReactNode;
 };
 
 export function Sidebar({
   collapsed,
   activeTab,
-  onChangeTab,
   outline,
   ai,
+  chat,
+  analysis,
   history,
 }: SidebarProps) {
   if (collapsed) {
@@ -25,37 +36,17 @@ export function Sidebar({
   }
 
   return (
-    <aside className="sidebar">
-      <div className="sidebar-tabs">
-        <button
-          type="button"
-          className={activeTab === "outline" ? "sidebar-tab active" : "sidebar-tab"}
-          onClick={() => onChangeTab("outline")}
-        >
-          문서 개요
-        </button>
-        <button
-          type="button"
-          className={activeTab === "ai" ? "sidebar-tab active" : "sidebar-tab"}
-          onClick={() => onChangeTab("ai")}
-        >
-          AI 제안
-        </button>
-        <button
-          type="button"
-          className={activeTab === "history" ? "sidebar-tab active" : "sidebar-tab"}
-          onClick={() => onChangeTab("history")}
-        >
-          수정 이력
-        </button>
+    <aside className={styles.panel}>
+      <div className={styles.panelTitleBar}>
+        {TAB_LABELS[activeTab] ?? ""}
       </div>
-
-      <div className="sidebar-content">
+      <div className={activeTab === "chat" ? styles.panelContentChat : styles.panelContent}>
         {activeTab === "outline" ? outline : null}
         {activeTab === "ai" ? ai : null}
+        {activeTab === "chat" ? chat : null}
+        {activeTab === "analysis" ? analysis : null}
         {activeTab === "history" ? history : null}
       </div>
     </aside>
   );
 }
-

--- a/src/lib/chat/chat-stream.ts
+++ b/src/lib/chat/chat-stream.ts
@@ -1,0 +1,118 @@
+import type { ChatRequest, ToolCallInfo, ToolResultInfo } from "@/types/chat";
+
+export type ChatStreamCallbacks = {
+  onTextDelta: (text: string) => void;
+  onToolCall: (toolCall: ToolCallInfo) => void;
+  onToolResult: (result: ToolResultInfo) => void;
+  onToolPending: (toolCall: ToolCallInfo) => void;
+  onDone: (usage: { inputTokens: number; outputTokens: number }) => void;
+  onError: (message: string) => void;
+};
+
+/**
+ * Stream a POST request to /api/chat and parse SSE events.
+ * Uses fetch + ReadableStream (EventSource only supports GET).
+ */
+export async function streamChat(
+  request: ChatRequest,
+  callbacks: ChatStreamCallbacks,
+): Promise<void> {
+  const response = await fetch("/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    let msg = `API error: ${response.status}`;
+    try {
+      const json = JSON.parse(text);
+      msg = json.error || msg;
+    } catch {
+      // ignore
+    }
+    callbacks.onError(msg);
+    return;
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    callbacks.onError("No response body");
+    return;
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  let currentEvent = "";
+  let currentData = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // Parse SSE events from buffer
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || ""; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (line.startsWith("event: ")) {
+          currentEvent = line.slice(7).trim();
+        } else if (line.startsWith("data: ")) {
+          currentData = line.slice(6);
+        } else if (line === "") {
+          if (currentEvent && currentData) {
+            processSSEEvent(currentEvent, currentData, callbacks);
+          }
+          currentEvent = "";
+          currentData = "";
+        }
+      }
+    }
+
+    // Process any remaining buffered event
+    if (currentEvent && currentData) {
+      processSSEEvent(currentEvent, currentData, callbacks);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function processSSEEvent(
+  event: string,
+  data: string,
+  callbacks: ChatStreamCallbacks,
+) {
+  try {
+    const parsed = JSON.parse(data);
+
+    switch (event) {
+      case "text_delta":
+        callbacks.onTextDelta(parsed.content);
+        break;
+      case "tool_call":
+        callbacks.onToolCall(parsed.toolCall);
+        break;
+      case "tool_result":
+        callbacks.onToolResult(parsed.result);
+        break;
+      case "tool_pending":
+        callbacks.onToolPending(parsed.toolCall);
+        break;
+      case "done":
+        callbacks.onDone(parsed.usage || { inputTokens: 0, outputTokens: 0 });
+        break;
+      case "error":
+        callbacks.onError(parsed.message || "Unknown error");
+        break;
+    }
+  } catch {
+    // Malformed SSE data, skip
+  }
+}
+

--- a/src/lib/editor/ai-presets.ts
+++ b/src/lib/editor/ai-presets.ts
@@ -1,0 +1,72 @@
+export type PresetKey =
+  | "technical_proposal"
+  | "official_document"
+  | "research_report"
+  | "business_plan"
+  | "korean_proofreading"
+  | "honorific_unify"
+  | "concise_rewrite"
+  | "yearly_update"
+  | "custom";
+
+export type InstructionPreset = {
+  key: PresetKey;
+  label: string;
+  instruction: string;
+};
+
+export const INSTRUCTION_PRESETS: InstructionPreset[] = [
+  {
+    key: "technical_proposal",
+    label: "기술제안서",
+    instruction:
+      "기술 제안서 톤으로 다듬어라. 평가위원이 30초 내 핵심을 파악할 수 있도록 간결하게 작성하라. 전문 용어는 유지하되 수동태보다 능동태를 사용하고, 정량적 근거를 보강하라.",
+  },
+  {
+    key: "official_document",
+    label: "공문서",
+    instruction:
+      "공문서 어투(합쇼체, '~함' 체)로 수정하라. 행정용어를 정확하게 사용하고, 높임말을 통일하라. 불필요한 미사여구를 제거하고 간결하게 작성하라.",
+  },
+  {
+    key: "research_report",
+    label: "연구보고서",
+    instruction:
+      "학술 연구보고서 톤으로 수정하라. 객관적 서술체를 사용하고, 인과관계를 명확히 하라. 약어 사용 시 최초 언급에서 풀어쓰고, 인용 형식을 보존하라.",
+  },
+  {
+    key: "business_plan",
+    label: "사업계획서",
+    instruction:
+      "사업계획서 톤으로 다듬어라. 수치와 근거를 강조하고 실현 가능성이 드러나도록 서술하라. 모호한 표현을 구체적 수치로 바꾸고 투자자 관점에서 설득력 있게 작성하라.",
+  },
+  {
+    key: "korean_proofreading",
+    label: "맞춤법/띄어쓰기",
+    instruction:
+      "한국어 맞춤법과 띄어쓰기를 교정하라. 국립국어원 표준어 규정을 따르고, 자주 틀리는 표현(예: '되'와 '돼', '로서'와 '로써', 사이시옷, 두음법칙)을 정확하게 수정하라. 의미나 문체는 변경하지 말고 표기법만 수정하라.",
+  },
+  {
+    key: "honorific_unify",
+    label: "존댓말 통일",
+    instruction:
+      "문서 전체의 존댓말 레벨을 합쇼체(~합니다, ~입니다)로 통일하라. 해요체(~해요), 해라체(~한다), 반말이 섞여있으면 모두 합쇼체로 변환하라. 명사형 종결(~함, ~임)은 보존하되, 서술문은 반드시 합쇼체로 맞춰라.",
+  },
+  {
+    key: "concise_rewrite",
+    label: "간결하게 다듬기",
+    instruction:
+      "문장을 간결하고 명확하게 다듬어라. 불필요한 수식어, 중복 표현, 피동 표현을 제거하고 능동태로 변환하라. 핵심 정보를 앞으로 배치하고, 한 문장이 50자를 넘지 않도록 분리하라. 원문의 의미는 보존하라.",
+  },
+  {
+    key: "yearly_update",
+    label: "연도/수치 업데이트",
+    instruction:
+      "이 문서는 작년도 문서를 올해 기준으로 업데이트하려는 것이다. 다음을 수행하라: 1) 연도 표기(2024→2025, 제N기→제N+1기 등)를 최신으로 변경하라. 2) 날짜/기간 표현을 현행화하라. 3) 수치나 통계가 포함된 부분은 [업데이트 필요]로 표시하여 사용자가 확인할 수 있게 하라. 4) 정책 용어나 제도명이 변경되었을 가능성이 있는 부분도 [확인 필요]로 표시하라. 서식과 문체는 원본 그대로 유지하라.",
+  },
+  {
+    key: "custom",
+    label: "직접 입력",
+    instruction: "",
+  },
+];

--- a/src/lib/editor/batch-ai.ts
+++ b/src/lib/editor/batch-ai.ts
@@ -8,6 +8,8 @@ export type BatchSuggestionInput = {
   id: string;
   text: string;
   styleHints: Record<string, string>;
+  prevText?: string;
+  nextText?: string;
 };
 
 export type BatchSuggestionResult = {
@@ -106,16 +108,20 @@ export function collectSectionBatchItems(
     }
   }
 
-  return segments
-    .filter((segment) => targetSectionId === null || segment.sectionId === targetSectionId)
-    .map((segment) => ({
-      id: segment.segmentId,
-      text: segment.text,
-      styleHints: {
-        sectionTitle: segment.sectionTitle,
-        nodeType: segment.nodeType,
-      },
-    }));
+  const filtered = segments.filter(
+    (segment) => targetSectionId === null || segment.sectionId === targetSectionId,
+  );
+
+  return filtered.map((segment, index) => ({
+    id: segment.segmentId,
+    text: segment.text,
+    styleHints: {
+      sectionTitle: segment.sectionTitle,
+      nodeType: segment.nodeType,
+    },
+    prevText: index > 0 ? filtered[index - 1].text : undefined,
+    nextText: index < filtered.length - 1 ? filtered[index + 1].text : undefined,
+  }));
 }
 
 export function buildBatchApplyPlan(

--- a/src/lib/editor/diff-highlight-extension.ts
+++ b/src/lib/editor/diff-highlight-extension.ts
@@ -1,0 +1,103 @@
+import { Extension } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { Node as PMNode } from "@tiptap/pm/model";
+
+export type DiffHighlightSuggestion = {
+  segmentId: string;
+  originalText: string;
+  suggestion: string;
+  decision?: "accepted" | "rejected" | undefined;
+};
+
+const DIFF_HIGHLIGHT_PLUGIN_KEY = new PluginKey<DecorationSet>("diffHighlight");
+const DIFF_HIGHLIGHT_META = "diffHighlightUpdate";
+
+function buildDecorations(
+  doc: PMNode,
+  suggestions: DiffHighlightSuggestion[],
+): DecorationSet {
+  if (!suggestions.length) {
+    return DecorationSet.empty;
+  }
+
+  const suggestionMap = new Map<string, DiffHighlightSuggestion>();
+  for (const s of suggestions) {
+    suggestionMap.set(s.segmentId, s);
+  }
+
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, pos) => {
+    if (node.type.name !== "paragraph" && node.type.name !== "heading") {
+      return true;
+    }
+    const attrs = node.attrs as { segmentId?: string };
+    if (!attrs.segmentId || !suggestionMap.has(attrs.segmentId)) {
+      return true;
+    }
+
+    const suggestion = suggestionMap.get(attrs.segmentId)!;
+    let cssClass = "diff-pending";
+    if (suggestion.decision === "accepted") {
+      cssClass = "diff-accepted";
+    } else if (suggestion.decision === "rejected") {
+      cssClass = "diff-rejected";
+    }
+
+    decorations.push(
+      Decoration.node(pos, pos + node.nodeSize, {
+        class: cssClass,
+        "data-diff-segment": attrs.segmentId,
+      }),
+    );
+
+    return true;
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export const DiffHighlightExtension = Extension.create({
+  name: "diffHighlight",
+
+  addStorage() {
+    return {
+      suggestions: [] as DiffHighlightSuggestion[],
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const extension = this;
+
+    return [
+      new Plugin<DecorationSet>({
+        key: DIFF_HIGHLIGHT_PLUGIN_KEY,
+
+        state: {
+          init(_, state) {
+            return buildDecorations(state.doc, extension.storage.suggestions);
+          },
+          apply(tr, oldDecorations, _oldState, newState) {
+            if (tr.getMeta(DIFF_HIGHLIGHT_META) || tr.docChanged) {
+              return buildDecorations(newState.doc, extension.storage.suggestions);
+            }
+            return oldDecorations.map(tr.mapping, tr.doc);
+          },
+        },
+
+        props: {
+          decorations(state) {
+            return DIFF_HIGHLIGHT_PLUGIN_KEY.getState(state) ?? DecorationSet.empty;
+          },
+        },
+      }),
+    ];
+  },
+});
+
+export function triggerDiffHighlightUpdate(editor: Editor): void {
+  const tr = editor.state.tr.setMeta(DIFF_HIGHLIGHT_META, true);
+  editor.view.dispatch(tr);
+}

--- a/src/lib/editor/docx-to-prosemirror.ts
+++ b/src/lib/editor/docx-to-prosemirror.ts
@@ -1,0 +1,224 @@
+import mammoth from "mammoth";
+import type { JSONContent } from "@tiptap/core";
+import type { EditorSegment, ParsedProseMirrorDocument } from "./hwpx-to-prosemirror";
+
+const SOURCE_NAME = "docx";
+
+/**
+ * Parse a DOCX file into ProseMirror JSONContent + EditorSegments.
+ * Uses mammoth.js for DOCX→HTML, then walks the DOM to build TipTap-compatible JSON.
+ */
+export async function parseDocxToProseMirror(
+  fileBuffer: ArrayBuffer,
+): Promise<ParsedProseMirrorDocument> {
+  const result = await mammoth.convertToHtml({ arrayBuffer: fileBuffer });
+  const html = result.value;
+  const warnings = result.messages
+    .filter((m) => m.type === "warning")
+    .map((m) => m.message);
+
+  const parser = new DOMParser();
+  const dom = parser.parseFromString(html, "text/html");
+
+  const content: JSONContent[] = [];
+  const segments: EditorSegment[] = [];
+  let textIndex = 0;
+
+  for (const child of Array.from(dom.body.children)) {
+    const tag = child.tagName.toLowerCase();
+
+    if (tag === "table") {
+      const tableJson = processTable(child as HTMLTableElement);
+      if (tableJson) content.push(tableJson);
+      continue;
+    }
+
+    if (tag === "ul" || tag === "ol") {
+      // Flatten list items into paragraphs (TipTap StarterKit doesn't have bulletList by default)
+      for (const li of Array.from(child.querySelectorAll("li"))) {
+        const text = li.textContent?.trim() || "";
+        if (!text) continue;
+        const prefix = tag === "ol" ? `${textIndex + 1}. ` : "• ";
+        const segmentId = `${SOURCE_NAME}::${textIndex}`;
+        const fullText = prefix + text;
+        segments.push({
+          segmentId,
+          fileName: SOURCE_NAME,
+          textIndex,
+          text: fullText,
+          originalText: fullText,
+          tag: "p",
+          styleHints: {},
+        });
+        content.push({
+          type: "paragraph",
+          attrs: { segmentId, fileName: SOURCE_NAME, textIndex, originalText: fullText },
+          content: processInlineContent(li, prefix),
+        });
+        textIndex++;
+      }
+      continue;
+    }
+
+    // Headings
+    const headingMatch = tag.match(/^h([1-6])$/);
+    if (headingMatch) {
+      const level = Math.min(Number(headingMatch[1]), 3) as 1 | 2 | 3;
+      const text = child.textContent?.trim() || "";
+      if (!text) continue;
+      const segmentId = `${SOURCE_NAME}::${textIndex}`;
+      segments.push({
+        segmentId,
+        fileName: SOURCE_NAME,
+        textIndex,
+        text,
+        originalText: text,
+        tag: `h${level}`,
+        styleHints: {},
+      });
+      content.push({
+        type: "heading",
+        attrs: { level, segmentId, fileName: SOURCE_NAME, textIndex, originalText: text },
+        content: processInlineContent(child),
+      });
+      textIndex++;
+      continue;
+    }
+
+    // Paragraphs and other block elements → paragraph
+    const text = child.textContent?.trim() || "";
+    if (!text) continue;
+    const segmentId = `${SOURCE_NAME}::${textIndex}`;
+    segments.push({
+      segmentId,
+      fileName: SOURCE_NAME,
+      textIndex,
+      text,
+      originalText: text,
+      tag: "p",
+      styleHints: {},
+    });
+    content.push({
+      type: "paragraph",
+      attrs: { segmentId, fileName: SOURCE_NAME, textIndex, originalText: text },
+      content: processInlineContent(child),
+    });
+    textIndex++;
+  }
+
+  // Ensure at least one paragraph
+  if (content.length === 0) {
+    content.push({ type: "paragraph" });
+  }
+
+  return {
+    doc: { type: "doc", content },
+    segments,
+    extraSegmentsMap: {},
+    integrityIssues: warnings,
+  };
+}
+
+/* ── Inline content processing ── */
+
+type MarkDef = { type: string; attrs?: Record<string, unknown> };
+
+function getMarksForTag(tag: string): MarkDef[] {
+  switch (tag) {
+    case "strong":
+    case "b":
+      return [{ type: "bold" }];
+    case "em":
+    case "i":
+      return [{ type: "italic" }];
+    case "u":
+      return [{ type: "underline" }];
+    case "s":
+    case "del":
+    case "strike":
+      return [{ type: "strike" }];
+    case "sup":
+      return [{ type: "superscript" }];
+    case "sub":
+      return [{ type: "subscript" }];
+    default:
+      return [];
+  }
+}
+
+function processInlineContent(
+  element: Element | ChildNode,
+  prefix?: string,
+): JSONContent[] {
+  const result: JSONContent[] = [];
+
+  if (prefix) {
+    result.push({ type: "text", text: prefix });
+  }
+
+  for (const child of Array.from(element.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const text = child.textContent || "";
+      if (text) result.push({ type: "text", text });
+      continue;
+    }
+
+    if (child.nodeType !== Node.ELEMENT_NODE) continue;
+    const el = child as Element;
+    const tag = el.tagName.toLowerCase();
+
+    if (tag === "br") {
+      result.push({ type: "hardBreak" });
+      continue;
+    }
+
+    // Recursively process and collect marks
+    const inner = processInlineContent(el);
+    const marks = getMarksForTag(tag);
+
+    if (marks.length > 0) {
+      for (const item of inner) {
+        if (item.type === "text") {
+          item.marks = [...(item.marks || []), ...marks];
+        }
+      }
+    }
+    result.push(...inner);
+  }
+
+  return result;
+}
+
+/* ── Table processing ── */
+
+function processTable(table: HTMLTableElement): JSONContent | null {
+  const rows: JSONContent[] = [];
+
+  for (const tr of Array.from(table.querySelectorAll("tr"))) {
+    const cells: JSONContent[] = [];
+    for (const td of Array.from(tr.querySelectorAll("td, th"))) {
+      const isHeader = td.tagName.toLowerCase() === "th";
+      const colspan = Number(td.getAttribute("colspan")) || 1;
+      const rowspan = Number(td.getAttribute("rowspan")) || 1;
+      const cellContent = processInlineContent(td);
+
+      cells.push({
+        type: isHeader ? "tableHeader" : "tableCell",
+        attrs: { colspan, rowspan },
+        content: [
+          {
+            type: "paragraph",
+            content: cellContent.length > 0 ? cellContent : undefined,
+          },
+        ],
+      });
+    }
+    if (cells.length > 0) {
+      rows.push({ type: "tableRow", content: cells });
+    }
+  }
+
+  if (rows.length === 0) return null;
+
+  return { type: "table", content: rows };
+}

--- a/src/lib/editor/export-docx.ts
+++ b/src/lib/editor/export-docx.ts
@@ -1,0 +1,178 @@
+import {
+  Document,
+  Paragraph,
+  TextRun,
+  HeadingLevel,
+  Table,
+  TableRow,
+  TableCell,
+  WidthType,
+  Packer,
+  AlignmentType,
+  BorderStyle,
+} from "docx";
+import type { JSONContent } from "@tiptap/core";
+
+/**
+ * Convert TipTap JSONContent to a DOCX Blob.
+ */
+export async function exportToDocx(
+  doc: JSONContent,
+  fileName: string,
+): Promise<{ blob: Blob; fileName: string }> {
+  const children = (doc.content || []).flatMap(convertNode);
+
+  const document = new Document({
+    sections: [
+      {
+        properties: {
+          page: {
+            margin: { top: 1440, bottom: 1440, left: 1440, right: 1440 }, // 1 inch
+          },
+        },
+        children,
+      },
+    ],
+  });
+
+  const blob = await Packer.toBlob(document);
+  const exportName = fileName.replace(/\.(hwpx|docx|pptx)$/i, "") + ".docx";
+  return { blob, fileName: exportName };
+}
+
+type DocxChild = Paragraph | Table;
+
+function convertNode(node: JSONContent): DocxChild[] {
+  switch (node.type) {
+    case "heading":
+      return [convertHeading(node)];
+    case "paragraph":
+      return [convertParagraph(node)];
+    case "table":
+      return convertTable(node);
+    case "horizontalRule":
+      return [
+        new Paragraph({
+          border: { bottom: { style: BorderStyle.SINGLE, size: 1, color: "999999" } },
+          spacing: { before: 200, after: 200 },
+        }),
+      ];
+    default:
+      // Fallback: try to extract text
+      if (node.content) {
+        return node.content.flatMap(convertNode);
+      }
+      return [];
+  }
+}
+
+function convertHeading(node: JSONContent): Paragraph {
+  const level = (node.attrs?.level as number) || 1;
+  const headingLevel =
+    level === 1
+      ? HeadingLevel.HEADING_1
+      : level === 2
+        ? HeadingLevel.HEADING_2
+        : HeadingLevel.HEADING_3;
+
+  return new Paragraph({
+    heading: headingLevel,
+    children: convertInlineContent(node.content || []),
+    alignment: getAlignment(node.attrs?.textAlign as string),
+  });
+}
+
+function convertParagraph(node: JSONContent): Paragraph {
+  return new Paragraph({
+    children: convertInlineContent(node.content || []),
+    alignment: getAlignment(node.attrs?.textAlign as string),
+    spacing: { line: 360 }, // 1.5 line spacing
+  });
+}
+
+function convertInlineContent(content: JSONContent[]): TextRun[] {
+  const runs: TextRun[] = [];
+
+  for (const node of content) {
+    if (node.type === "text") {
+      const marks = node.marks || [];
+      const bold = marks.some((m) => m.type === "bold");
+      const italic = marks.some((m) => m.type === "italic");
+      const underline = marks.some((m) => m.type === "underline");
+      const strike = marks.some((m) => m.type === "strike");
+
+      runs.push(
+        new TextRun({
+          text: node.text || "",
+          bold,
+          italics: italic,
+          underline: underline ? {} : undefined,
+          strike,
+          font: "Malgun Gothic",
+          size: 22, // 11pt
+        }),
+      );
+    } else if (node.type === "hardBreak") {
+      runs.push(new TextRun({ break: 1 }));
+    }
+  }
+
+  return runs;
+}
+
+function convertTable(node: JSONContent): DocxChild[] {
+  if (!node.content) return [];
+
+  const rows = node.content
+    .filter((row) => row.type === "tableRow")
+    .map((row) => {
+      const cells = (row.content || [])
+        .filter((cell) => cell.type === "tableCell" || cell.type === "tableHeader")
+        .map((cell) => {
+          const isHeader = cell.type === "tableHeader";
+          const colspan = (cell.attrs?.colspan as number) || 1;
+          const rowspan = (cell.attrs?.rowspan as number) || 1;
+          const innerContent = (cell.content || []).flatMap((p) =>
+            convertInlineContent(p.content || []),
+          );
+
+          return new TableCell({
+            columnSpan: colspan,
+            rowSpan: rowspan,
+            children: [
+              new Paragraph({
+                children:
+                  innerContent.length > 0
+                    ? innerContent.map(
+                        (run) =>
+                          new TextRun({
+                            ...run,
+                            bold: isHeader ? true : (run as unknown as { options: { bold?: boolean } }).options?.bold,
+                          } as unknown as ConstructorParameters<typeof TextRun>[0]),
+                      )
+                    : [new TextRun({ text: "" })],
+              }),
+            ],
+            width: { size: 100 / ((row.content || []).length || 1), type: WidthType.PERCENTAGE },
+          });
+        });
+
+      return new TableRow({ children: cells });
+    });
+
+  if (rows.length === 0) return [];
+  return [new Table({ rows, width: { size: 100, type: WidthType.PERCENTAGE } })];
+}
+
+function getAlignment(align: string | undefined): (typeof AlignmentType)[keyof typeof AlignmentType] | undefined {
+  switch (align) {
+    case "center":
+      return AlignmentType.CENTER;
+    case "right":
+      return AlignmentType.RIGHT;
+    case "justify":
+      return AlignmentType.JUSTIFIED;
+    default:
+      return undefined;
+  }
+}

--- a/src/lib/editor/export-pdf.ts
+++ b/src/lib/editor/export-pdf.ts
@@ -1,0 +1,93 @@
+/**
+ * Export editor content to PDF via the browser's native print dialog.
+ * Opens a styled print window with A4 layout and triggers window.print().
+ * The user can then "Save as PDF" from the system dialog.
+ */
+export function exportToPdf(editorElement: HTMLElement, fileName: string) {
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) {
+    alert("팝업이 차단되었습니다. 팝업 차단을 해제해주세요.");
+    return;
+  }
+
+  // Clone only the ProseMirror content
+  const proseMirror = editorElement.querySelector(".ProseMirror");
+  const contentHtml = proseMirror ? proseMirror.innerHTML : editorElement.innerHTML;
+
+  const title = fileName.replace(/\.(hwpx|docx)$/i, "");
+
+  printWindow.document.write(`<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>${escapeHtml(title)}</title>
+<style>
+  @page {
+    size: A4;
+    margin: 20mm 15mm;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: "바탕", "Batang", "Malgun Gothic", serif;
+    font-size: 11pt;
+    line-height: 1.6;
+    color: #000;
+    background: #fff;
+  }
+  h1, h2, h3 {
+    margin-top: 1.2em;
+    margin-bottom: 0.4em;
+    page-break-after: avoid;
+  }
+  h1 { font-size: 18pt; }
+  h2 { font-size: 14pt; }
+  h3 { font-size: 12pt; }
+  p {
+    margin-bottom: 0.5em;
+    text-align: justify;
+    orphans: 3;
+    widows: 3;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.8em 0;
+    page-break-inside: avoid;
+  }
+  td, th {
+    border: 1px solid #333;
+    padding: 4px 6px;
+    font-size: 10pt;
+    vertical-align: top;
+  }
+  th { background: #f0f0f0; font-weight: bold; }
+  hr { border: none; border-top: 1px solid #999; margin: 1em 0; }
+  /* Remove editor artifacts */
+  .diff-pending, .diff-accepted, .diff-rejected {
+    border-left: none !important;
+    background: none !important;
+    padding-left: 0 !important;
+  }
+  @media print {
+    body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  }
+</style>
+</head>
+<body>
+${contentHtml}
+<script>
+  window.onafterprint = function() { window.close(); };
+  setTimeout(function() { window.print(); }, 300);
+<\/script>
+</body>
+</html>`);
+  printWindow.document.close();
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/lib/editor/extensions.ts
+++ b/src/lib/editor/extensions.ts
@@ -4,8 +4,14 @@ import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
 import Placeholder from "@tiptap/extension-placeholder";
+import Underline from "@tiptap/extension-underline";
+import TextAlign from "@tiptap/extension-text-align";
+import FontFamily from "@tiptap/extension-font-family";
+import { TextStyle } from "@tiptap/extension-text-style";
 import { HwpxMetadataExtension } from "./schema";
 import { SlashCommandExtension } from "./slash-commands";
+import { DiffHighlightExtension } from "./diff-highlight-extension";
+import { OfficePasteExtension } from "./office-paste-extension";
 
 type EditorExtensionOptions = {
   onAiCommand?: () => void;
@@ -17,6 +23,14 @@ export function createEditorExtensions(options: EditorExtensionOptions = {}) {
       heading: {
         levels: [1, 2, 3],
       },
+    }),
+    TextStyle,
+    FontFamily.configure({
+      types: ["textStyle"],
+    }),
+    Underline,
+    TextAlign.configure({
+      types: ["heading", "paragraph"],
     }),
     Table.configure({
       resizable: true,
@@ -31,5 +45,7 @@ export function createEditorExtensions(options: EditorExtensionOptions = {}) {
     SlashCommandExtension.configure({
       onAiCommand: options.onAiCommand,
     }),
+    DiffHighlightExtension,
+    OfficePasteExtension,
   ];
 }

--- a/src/lib/editor/hwpx-to-prosemirror.test.ts
+++ b/src/lib/editor/hwpx-to-prosemirror.test.ts
@@ -78,6 +78,40 @@ async function makeFixtureHwpx(): Promise<ArrayBuffer> {
   return zip.generateAsync({ type: "arraybuffer", compression: "DEFLATE" });
 }
 
+async function makeLetterSpacingFixtureHwpx(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file("mimetype", "application/hwp+zip", { compression: "STORE" });
+  zip.file("version.xml", `<?xml version="1.0" encoding="UTF-8"?><version app="test"/>`);
+  zip.file(
+    "Contents/content.hpf",
+    `<?xml version="1.0" encoding="UTF-8"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf"></opf:package>`,
+  );
+  zip.file(
+    "Contents/header.xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="2">
+      <hh:charPr id="1">
+        <hh:spacing hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+      <hh:charPr id="2">
+        <hh:spacing hangul="-10" latin="-10" hanja="-10" japanese="-10" other="-10" symbol="-10" user="-10"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>`,
+  );
+  zip.file(
+    "Contents/section0.xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<hp:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:p><hp:run charPrIDRef="2"><hp:t>자간 테스트</hp:t></hp:run></hp:p>
+</hp:sec>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer", compression: "DEFLATE" });
+}
+
 describe("parseHwpxToProseMirror – multi-run merging", () => {
   it("merges multiple <hp:t> runs in the same <hp:p> into one paragraph", async () => {
     const dom = new JSDOM("");
@@ -166,5 +200,21 @@ describe("parseHwpxToProseMirror", () => {
       { type: "hardBreak" },
       { type: "text", text: "둘째 줄" },
     ]);
+  });
+
+  it("reads run charPr spacing from header.xml into paragraph letterSpacing attrs", async () => {
+    const dom = new JSDOM("");
+    (globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = dom.window.DOMParser;
+    (globalThis as unknown as { NodeFilter: typeof NodeFilter }).NodeFilter = dom.window.NodeFilter;
+
+    const input = await makeLetterSpacingFixtureHwpx();
+    const parsed = await parseHwpxToProseMirror(input);
+
+    expect(parsed.segments).toHaveLength(1);
+    expect(parsed.segments[0].styleHints.charPrIDRef).toBe("2");
+    expect(parsed.segments[0].styleHints.hwpxCharSpacing).toBe("-10");
+
+    const paragraph = (parsed.doc.content || []).find((node) => node.type === "paragraph");
+    expect((paragraph?.attrs || {}) as { letterSpacing?: number }).toMatchObject({ letterSpacing: -10 });
   });
 });

--- a/src/lib/editor/hwpx-to-prosemirror.ts
+++ b/src/lib/editor/hwpx-to-prosemirror.ts
@@ -21,6 +21,101 @@ export type ParsedProseMirrorDocument = {
 };
 
 const SECTION_FILE_RE = /^Contents\/section\d+\.xml$/;
+const HEADER_FILE = "Contents/header.xml";
+
+/**
+ * Parse Contents/header.xml and build a map from borderFill id → CSS background color.
+ * HWPX stores cell/paragraph fill info as <borderFill> elements in the header.
+ * The fill color is in <fillBrush><winBrush faceColor="#RRGGBB"/></fillBrush>.
+ */
+function extractBorderFillColors(doc: Document): Map<string, string> {
+  const map = new Map<string, string>();
+  const allElements = Array.from(doc.getElementsByTagName("*"));
+  for (const el of allElements) {
+    if (el.localName !== "borderFill") {
+      continue;
+    }
+    const id = el.getAttribute("id");
+    if (!id) {
+      continue;
+    }
+    // Navigate: borderFill → fillBrush → winBrush @faceColor
+    for (const child of Array.from(el.children)) {
+      if (child.localName !== "fillBrush") {
+        continue;
+      }
+      for (const grandchild of Array.from(child.children)) {
+        if (grandchild.localName !== "winBrush") {
+          continue;
+        }
+        const faceColor = grandchild.getAttribute("faceColor");
+        if (faceColor && faceColor !== "none" && faceColor !== "#FFFFFF" && faceColor !== "#ffffff") {
+          // Normalize: HWPX sometimes uses 8-digit #AARRGGBB; strip leading FF alpha
+          let color = faceColor;
+          if (/^#[0-9a-fA-F]{8}$/.test(color)) {
+            const alpha = Number.parseInt(color.slice(1, 3), 16);
+            if (alpha === 0) {
+              break; // fully transparent
+            }
+            color = `#${color.slice(3)}`;
+          }
+          map.set(id, color);
+        }
+      }
+    }
+  }
+  return map;
+}
+
+function readSignedIntAttr(element: Element, aliases: string[]): number | null {
+  const aliasSet = new Set(aliases.map((alias) => alias.toLowerCase()));
+  for (const attr of Array.from(element.attributes)) {
+    const normalizedName = attr.name.toLowerCase().replace(/^[^:]+:/, "");
+    if (!aliasSet.has(normalizedName)) {
+      continue;
+    }
+    const parsed = Number.parseInt(attr.value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse Contents/header.xml and build a map from charPr id → spacing value.
+ * We use hangul spacing first; if missing, fall back to latin/other slots.
+ */
+function extractCharPrSpacingMap(doc: Document): Map<string, number> {
+  const map = new Map<string, number>();
+  const allElements = Array.from(doc.getElementsByTagName("*"));
+  for (const el of allElements) {
+    if (el.localName !== "charPr") {
+      continue;
+    }
+    const id = el.getAttribute("id");
+    if (!id) {
+      continue;
+    }
+
+    const spacing = Array.from(el.children).find((child) => child.localName === "spacing");
+    if (!spacing) {
+      map.set(id, 0);
+      continue;
+    }
+    const value =
+      readSignedIntAttr(spacing, ["hangul"]) ??
+      readSignedIntAttr(spacing, ["latin"]) ??
+      readSignedIntAttr(spacing, ["hanja"]) ??
+      readSignedIntAttr(spacing, ["japanese"]) ??
+      readSignedIntAttr(spacing, ["other"]) ??
+      readSignedIntAttr(spacing, ["symbol"]) ??
+      readSignedIntAttr(spacing, ["user"]) ??
+      0;
+    map.set(id, value);
+  }
+  return map;
+}
 
 function isHeadingLike(text: string): boolean {
   const trimmed = text.trim();
@@ -51,13 +146,60 @@ function readPositiveIntAttr(element: Element, aliases: string[]): number | null
   return null;
 }
 
+/**
+ * Read colspan or rowspan from a <hp:tc> element.
+ * Real HWPX files store span info in a <hp:cellSpan colSpan="N" rowSpan="M"/>
+ * child element. Synthetic test fixtures may use direct attributes on <hp:tc>.
+ * This function checks direct attributes first, then <hp:cellSpan> children.
+ */
+function readCellSpan(cell: Element, attrAliases: string[], cellSpanAttr: string): number {
+  // 1. Check direct attributes on <hp:tc> (used by synthetic test fixtures)
+  const direct = readPositiveIntAttr(cell, attrAliases);
+  if (direct !== null) {
+    return direct;
+  }
+  // 2. Check <hp:cellSpan> child element (used in real HWPX files)
+  for (const child of Array.from(cell.children)) {
+    if (child.localName === "cellSpan") {
+      // The child uses camelCase attribute names: colSpan / rowSpan
+      const val = Number.parseInt(child.getAttribute(cellSpanAttr) || "0", 10);
+      if (Number.isFinite(val) && val > 1) {
+        return val;
+      }
+    }
+  }
+  return 1;
+}
+
+/**
+ * Returns true if this <hp:tc> is a "dirty" covered cell that should be
+ * hidden — i.e., it is subsumed by a spanning cell elsewhere in the table.
+ * In OWPML format, covered cells carry dirty="1".
+ */
+function isCoveredCell(cell: Element): boolean {
+  return cell.getAttribute("dirty") === "1";
+}
+
+function readSegmentLetterSpacing(segment: EditorSegment): number | null {
+  const raw = segment.styleHints.hwpxCharSpacing;
+  if (raw === undefined) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function toParagraphNode(segment: EditorSegment, asHeading: boolean): JSONContent {
-  const attrs = {
+  const letterSpacing = readSegmentLetterSpacing(segment);
+  const attrs: Record<string, string | number> = {
     segmentId: segment.segmentId,
     fileName: segment.fileName,
     textIndex: segment.textIndex,
     originalText: segment.originalText,
   };
+  if (letterSpacing !== null) {
+    attrs.letterSpacing = letterSpacing;
+  }
   const inlineContent: JSONContent[] = [];
   const chunks = segment.text.split(/\r\n|\r|\n/);
   for (const [index, chunk] of chunks.entries()) {
@@ -139,6 +281,37 @@ function getTextElementsExcludingNestedTables(parent: Element): Element[] {
   return result;
 }
 
+function findClosestRunElement(element: Element): Element | null {
+  let current: Element | null = element;
+  while (current) {
+    if (current.localName === "run") {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+function applyRunStyleHintsToSegment(
+  segment: EditorSegment,
+  textElement: Element,
+  charPrSpacingById: Map<string, number>,
+): void {
+  const run = findClosestRunElement(textElement);
+  if (!run) {
+    return;
+  }
+  const charPrIDRef = run.getAttribute("charPrIDRef");
+  if (!charPrIDRef) {
+    return;
+  }
+  segment.styleHints.charPrIDRef = charPrIDRef;
+  const spacing = charPrSpacingById.get(charPrIDRef);
+  if (spacing !== undefined) {
+    segment.styleHints.hwpxCharSpacing = String(spacing);
+  }
+}
+
 /**
  * For each <hp:t> element in textEls, retrieve its segment via direct Element
  * identity lookup (built by buildElementSegmentMap), merge multiple runs from
@@ -150,6 +323,7 @@ function consumeAndMergeParagraph(
   usedSegments: EditorSegment[],
   usedSet: Set<EditorSegment>,
   extraSegmentsMap: Record<string, string[]>,
+  charPrSpacingById: Map<string, number>,
   asHeading: boolean,
 ): JSONContent | null {
   const segments: EditorSegment[] = [];
@@ -161,6 +335,7 @@ function consumeAndMergeParagraph(
     if (!seg || usedSet.has(seg)) {
       continue;
     }
+    applyRunStyleHintsToSegment(seg, el, charPrSpacingById);
     usedSet.add(seg);
     usedSegments.push(seg);
     segments.push(seg);
@@ -188,6 +363,8 @@ function parseSectionNode(
   usedSegments: EditorSegment[],
   usedSet: Set<EditorSegment>,
   extraSegmentsMap: Record<string, string[]>,
+  borderFillColors: Map<string, string>,
+  charPrSpacingById: Map<string, number>,
 ): JSONContent[] {
   const content: JSONContent[] = [];
   const paragraphs = Array.from(sectionElement.children).filter((child) => child.localName === "p");
@@ -215,9 +392,15 @@ function parseSectionNode(
         for (const [rowIndex, row] of tableRows.entries()) {
           const tableCells = Array.from(row.children).filter((child) => child.localName === "tc");
           const cellNodes: JSONContent[] = [];
-          for (const [colIndex, cell] of tableCells.entries()) {
-            const sourceRowspan = readPositiveIntAttr(cell, ["rowspan", "row_span"]) || 1;
-            const sourceColspan = readPositiveIntAttr(cell, ["colspan", "col_span"]) || 1;
+          let colIndex = 0;
+          for (const cell of tableCells) {
+            // Skip covered/dirty cells — they are subsumed by a spanning cell
+            if (isCoveredCell(cell)) {
+              colIndex += 1;
+              continue;
+            }
+            const sourceRowspan = readCellSpan(cell, ["rowspan", "row_span"], "rowSpan");
+            const sourceColspan = readCellSpan(cell, ["colspan", "col_span"], "colSpan");
             const paragraphsInCell: JSONContent[] = [];
 
             // Group <hp:t> by their enclosing <hp:p> within <hp:subList>.
@@ -235,6 +418,7 @@ function parseSectionNode(
                     usedSegments,
                     usedSet,
                     extraSegmentsMap,
+                    charPrSpacingById,
                     false,
                   );
                   if (node) {
@@ -251,6 +435,7 @@ function parseSectionNode(
                 usedSegments,
                 usedSet,
                 extraSegmentsMap,
+                charPrSpacingById,
                 false,
               );
               if (node) {
@@ -271,11 +456,20 @@ function parseSectionNode(
             if (sourceColspan > 1) {
               cellAttrs.colspan = sourceColspan;
             }
+            // Apply cell background color from HWPX borderFill definition
+            const bfRef = cell.getAttribute("borderFillIDRef");
+            if (bfRef) {
+              const bgColor = borderFillColors.get(bfRef);
+              if (bgColor) {
+                cellAttrs.backgroundColor = bgColor;
+              }
+            }
             cellNodes.push({
               type: "tableCell",
               attrs: cellAttrs,
               content: paragraphsInCell.length ? paragraphsInCell : [{ type: "paragraph" }],
             });
+            colIndex += 1;
           }
           rowNodes.push({
             type: "tableRow",
@@ -307,6 +501,7 @@ function parseSectionNode(
       usedSegments,
       usedSet,
       extraSegmentsMap,
+      charPrSpacingById,
       false,
     );
     if (node) {
@@ -359,6 +554,22 @@ export async function parseHwpxToProseMirror(fileBuffer: ArrayBuffer): Promise<P
     file.sort((a, b) => a.textIndex - b.textIndex);
   }
 
+  // Extract cell background colors from Contents/header.xml borderFill definitions
+  let borderFillColors = new Map<string, string>();
+  let charPrSpacingById = new Map<string, number>();
+  if (zip.files[HEADER_FILE] && !zip.files[HEADER_FILE].dir) {
+    try {
+      const headerXml = await zip.files[HEADER_FILE].async("string");
+      const headerDoc = new DOMParser().parseFromString(headerXml, "application/xml");
+      if (!headerDoc.querySelector("parsererror")) {
+        borderFillColors = extractBorderFillColors(headerDoc);
+        charPrSpacingById = extractCharPrSpacingMap(headerDoc);
+      }
+    } catch {
+      // Non-fatal — proceed without fill colors
+    }
+  }
+
   const usedSegments: EditorSegment[] = [];
   const content: JSONContent[] = [];
   const extraSegmentsMap: Record<string, string[]> = {};
@@ -387,6 +598,8 @@ export async function parseHwpxToProseMirror(fileBuffer: ArrayBuffer): Promise<P
       usedSegments,
       usedSet,
       extraSegmentsMap,
+      borderFillColors,
+      charPrSpacingById,
     );
     content.push(...sectionBlocks);
   }

--- a/src/lib/editor/office-paste-extension.ts
+++ b/src/lib/editor/office-paste-extension.ts
@@ -1,0 +1,77 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+/**
+ * Cleans up HTML pasted from Microsoft Office (Word, PowerPoint, Excel).
+ * Removes mso-* styles, conditional comments, and normalizes the HTML
+ * so TipTap can parse it correctly.
+ */
+export const OfficePasteExtension = Extension.create({
+  name: "officePaste",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("officePaste"),
+        props: {
+          transformPastedHTML(html: string): string {
+            // Detect Office HTML by mso- styles or xmlns:o
+            if (!html.includes("mso-") && !html.includes("xmlns:o") && !html.includes("urn:schemas-microsoft-com")) {
+              return html;
+            }
+            return cleanOfficeHtml(html);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+function cleanOfficeHtml(html: string): string {
+  // Remove conditional comments: <!--[if ...]>...<![endif]-->
+  let cleaned = html.replace(/<!--\[if[\s\S]*?<!\[endif\]-->/gi, "");
+
+  // Remove XML declarations
+  cleaned = cleaned.replace(/<\?xml[\s\S]*?\?>/gi, "");
+
+  // Remove Office-specific tags (o:p, v:*, w:*, m:*)
+  cleaned = cleaned.replace(/<\/?(o|v|w|m|st\d):[^>]*>/gi, "");
+
+  // Remove class attributes (Office generates tons of class names)
+  cleaned = cleaned.replace(/\s+class\s*=\s*["'][^"']*["']/gi, "");
+
+  // Clean style attributes: remove mso-* properties
+  cleaned = cleaned.replace(/\s+style\s*=\s*["']([^"']*)["']/gi, (_match, styleContent: string) => {
+    const cleanedStyle = styleContent
+      .split(";")
+      .map((prop: string) => prop.trim())
+      .filter((prop: string) => {
+        if (!prop) return false;
+        // Remove mso-* properties
+        if (/^mso-/i.test(prop)) return false;
+        // Remove Office-specific properties
+        if (/^(tab-stops|text-indent|margin-bottom:\s*\.0001pt)/i.test(prop)) return false;
+        return true;
+      })
+      .join("; ");
+
+    return cleanedStyle ? ` style="${cleanedStyle}"` : "";
+  });
+
+  // Remove empty spans
+  cleaned = cleaned.replace(/<span\s*>\s*<\/span>/gi, "");
+
+  // Remove &nbsp; used for spacing (common in Office HTML)
+  cleaned = cleaned.replace(/&nbsp;/g, " ");
+
+  // Remove empty paragraphs with only whitespace
+  cleaned = cleaned.replace(/<p[^>]*>\s*<\/p>/gi, "");
+
+  // Normalize <b> → <strong>, <i> → <em>
+  cleaned = cleaned.replace(/<b(\s|>)/gi, "<strong$1");
+  cleaned = cleaned.replace(/<\/b>/gi, "</strong>");
+  cleaned = cleaned.replace(/<i(\s|>)/gi, "<em$1");
+  cleaned = cleaned.replace(/<\/i>/gi, "</em>");
+
+  return cleaned;
+}

--- a/src/lib/editor/pptx-to-prosemirror.ts
+++ b/src/lib/editor/pptx-to-prosemirror.ts
@@ -1,0 +1,285 @@
+import JSZip from "jszip";
+import type { JSONContent } from "@tiptap/core";
+import type { EditorSegment, ParsedProseMirrorDocument } from "./hwpx-to-prosemirror";
+
+const SOURCE_NAME = "pptx";
+
+type SlideContent = {
+  slideNumber: number;
+  title: string;
+  bodyItems: string[];
+  tables: string[][][]; // rows × cols
+  notes: string;
+};
+
+/**
+ * Parse a PPTX file into ProseMirror JSONContent + EditorSegments.
+ * Extracts text/tables from slide XML, then converts flat slides into
+ * a hierarchical document structure.
+ */
+export async function parsePptxToProseMirror(
+  fileBuffer: ArrayBuffer,
+): Promise<ParsedProseMirrorDocument> {
+  const zip = await JSZip.loadAsync(fileBuffer);
+  const warnings: string[] = [];
+
+  // Find slide files
+  const slideFiles = Object.keys(zip.files)
+    .filter((name) => /^ppt\/slides\/slide\d+\.xml$/.test(name))
+    .sort((a, b) => {
+      const numA = Number(a.match(/slide(\d+)/)?.[1] || 0);
+      const numB = Number(b.match(/slide(\d+)/)?.[1] || 0);
+      return numA - numB;
+    });
+
+  if (slideFiles.length === 0) {
+    warnings.push("슬라이드를 찾을 수 없습니다.");
+    return {
+      doc: { type: "doc", content: [{ type: "paragraph" }] },
+      segments: [],
+      extraSegmentsMap: {},
+      integrityIssues: warnings,
+    };
+  }
+
+  // Extract content from each slide
+  const slides: SlideContent[] = [];
+  for (const slideFile of slideFiles) {
+    const xml = await zip.file(slideFile)?.async("string");
+    if (!xml) continue;
+    const slideNum = Number(slideFile.match(/slide(\d+)/)?.[1] || slides.length + 1);
+    const slide = parseSlideXml(xml, slideNum);
+    slides.push(slide);
+
+    // Try to get notes
+    const notesFile = slideFile.replace("slides/slide", "notesSlides/notesSlide");
+    const notesXml = await zip.file(notesFile)?.async("string");
+    if (notesXml) {
+      slide.notes = extractAllText(notesXml).join(" ").trim();
+    }
+  }
+
+  // Convert slides to document structure
+  return slidesToDocument(slides, warnings);
+}
+
+/* ── Slide XML parsing ── */
+
+function parseSlideXml(xml: string, slideNumber: number): SlideContent {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, "text/xml");
+
+  const title = extractShapeText(doc, "title") || extractShapeText(doc, "ctrTitle") || "";
+  const bodyItems = extractBodyItems(doc);
+  const tables = extractTables(doc);
+
+  return { slideNumber, title, bodyItems, tables, notes: "" };
+}
+
+/**
+ * Extract text from a named placeholder type (title, ctrTitle, body, subTitle).
+ */
+function extractShapeText(doc: Document, phType: string): string {
+  // Look for placeholder with idx/type matching
+  const spNodes = doc.getElementsByTagName("p:sp");
+  for (const sp of Array.from(spNodes)) {
+    const phNodes = sp.getElementsByTagName("p:ph");
+    for (const ph of Array.from(phNodes)) {
+      const type = ph.getAttribute("type") || "";
+      if (type.toLowerCase() === phType.toLowerCase()) {
+        return extractTextFromShape(sp);
+      }
+    }
+  }
+  return "";
+}
+
+function extractBodyItems(doc: Document): string[] {
+  const items: string[] = [];
+  const spNodes = doc.getElementsByTagName("p:sp");
+
+  for (const sp of Array.from(spNodes)) {
+    const phNodes = sp.getElementsByTagName("p:ph");
+    let isBody = false;
+    let isTitle = false;
+
+    for (const ph of Array.from(phNodes)) {
+      const type = (ph.getAttribute("type") || "").toLowerCase();
+      if (type === "body" || type === "subTitle" || type === "obj") isBody = true;
+      if (type === "title" || type === "ctrTitle") isTitle = true;
+    }
+
+    // If no placeholder type, treat as generic text box (body-like)
+    if (phNodes.length === 0) isBody = true;
+    if (isTitle) continue;
+
+    if (isBody) {
+      const paragraphs = sp.getElementsByTagName("a:p");
+      for (const p of Array.from(paragraphs)) {
+        const text = extractTextFromParagraph(p).trim();
+        if (text) items.push(text);
+      }
+    }
+  }
+
+  return items;
+}
+
+function extractTextFromShape(sp: Element): string {
+  const paragraphs = sp.getElementsByTagName("a:p");
+  const texts: string[] = [];
+  for (const p of Array.from(paragraphs)) {
+    const text = extractTextFromParagraph(p).trim();
+    if (text) texts.push(text);
+  }
+  return texts.join(" ");
+}
+
+function extractTextFromParagraph(p: Element): string {
+  const runs = p.getElementsByTagName("a:r");
+  const parts: string[] = [];
+  for (const r of Array.from(runs)) {
+    const tNodes = r.getElementsByTagName("a:t");
+    for (const t of Array.from(tNodes)) {
+      parts.push(t.textContent || "");
+    }
+  }
+  return parts.join("");
+}
+
+function extractAllText(xml: string): string[] {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, "text/xml");
+  const tNodes = doc.getElementsByTagName("a:t");
+  return Array.from(tNodes).map((t) => t.textContent || "").filter(Boolean);
+}
+
+function extractTables(doc: Document): string[][][] {
+  const tables: string[][][] = [];
+  const tblNodes = doc.getElementsByTagName("a:tbl");
+
+  for (const tbl of Array.from(tblNodes)) {
+    const rows: string[][] = [];
+    const trNodes = tbl.getElementsByTagName("a:tr");
+    for (const tr of Array.from(trNodes)) {
+      const cells: string[] = [];
+      const tcNodes = tr.getElementsByTagName("a:tc");
+      for (const tc of Array.from(tcNodes)) {
+        const text = Array.from(tc.getElementsByTagName("a:t"))
+          .map((t) => t.textContent || "")
+          .join("")
+          .trim();
+        cells.push(text);
+      }
+      rows.push(cells);
+    }
+    if (rows.length > 0) tables.push(rows);
+  }
+
+  return tables;
+}
+
+/* ── Convert slides to document ── */
+
+function slidesToDocument(
+  slides: SlideContent[],
+  warnings: string[],
+): ParsedProseMirrorDocument {
+  const content: JSONContent[] = [];
+  const segments: EditorSegment[] = [];
+  let textIndex = 0;
+
+  for (const slide of slides) {
+    // Slide title → H2
+    if (slide.title) {
+      const segmentId = `${SOURCE_NAME}::${textIndex}`;
+      segments.push({
+        segmentId,
+        fileName: SOURCE_NAME,
+        textIndex,
+        text: slide.title,
+        originalText: slide.title,
+        tag: "h2",
+        styleHints: {},
+      });
+      content.push({
+        type: "heading",
+        attrs: {
+          level: 2,
+          segmentId,
+          fileName: SOURCE_NAME,
+          textIndex,
+          originalText: slide.title,
+        },
+        content: [{ type: "text", text: slide.title }],
+      });
+      textIndex++;
+    }
+
+    // Body items → paragraphs
+    for (const item of slide.bodyItems) {
+      const segmentId = `${SOURCE_NAME}::${textIndex}`;
+      segments.push({
+        segmentId,
+        fileName: SOURCE_NAME,
+        textIndex,
+        text: item,
+        originalText: item,
+        tag: "p",
+        styleHints: {},
+      });
+      content.push({
+        type: "paragraph",
+        attrs: { segmentId, fileName: SOURCE_NAME, textIndex, originalText: item },
+        content: [{ type: "text", text: item }],
+      });
+      textIndex++;
+    }
+
+    // Tables
+    for (const table of slide.tables) {
+      const rows: JSONContent[] = table.map((row, ri) => ({
+        type: "tableRow",
+        content: row.map((cell) => ({
+          type: ri === 0 ? "tableHeader" : "tableCell",
+          attrs: { colspan: 1, rowspan: 1 },
+          content: [{ type: "paragraph", content: cell ? [{ type: "text", text: cell }] : undefined }],
+        })),
+      }));
+      content.push({ type: "table", content: rows });
+    }
+
+    // Notes → italic paragraph
+    if (slide.notes) {
+      const segmentId = `${SOURCE_NAME}::${textIndex}`;
+      const noteText = `[발표자 노트] ${slide.notes}`;
+      segments.push({
+        segmentId,
+        fileName: SOURCE_NAME,
+        textIndex,
+        text: noteText,
+        originalText: noteText,
+        tag: "p",
+        styleHints: {},
+      });
+      content.push({
+        type: "paragraph",
+        attrs: { segmentId, fileName: SOURCE_NAME, textIndex, originalText: noteText },
+        content: [{ type: "text", text: noteText, marks: [{ type: "italic" }] }],
+      });
+      textIndex++;
+    }
+  }
+
+  if (content.length === 0) {
+    content.push({ type: "paragraph" });
+    warnings.push("슬라이드에서 텍스트를 추출하지 못했습니다.");
+  }
+
+  return {
+    doc: { type: "doc", content },
+    segments,
+    extraSegmentsMap: {},
+    integrityIssues: warnings,
+  };
+}

--- a/src/lib/editor/prosemirror-to-hwpx.test.ts
+++ b/src/lib/editor/prosemirror-to-hwpx.test.ts
@@ -333,6 +333,40 @@ async function makeTableFixtureHwpx(): Promise<ArrayBuffer> {
   return zip.generateAsync({ type: "arraybuffer", compression: "DEFLATE" });
 }
 
+async function makeLetterSpacingFixtureHwpx(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file("mimetype", "application/hwp+zip", { compression: "STORE" });
+  zip.file("version.xml", `<?xml version="1.0" encoding="UTF-8"?><version app="test"/>`);
+  zip.file(
+    "Contents/content.hpf",
+    `<?xml version="1.0" encoding="UTF-8"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf"></opf:package>`,
+  );
+  zip.file(
+    "Contents/header.xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="2">
+      <hh:charPr id="1">
+        <hh:spacing hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+      <hh:charPr id="2">
+        <hh:spacing hangul="-5" latin="-5" hanja="-5" japanese="-5" other="-5" symbol="-5" user="-5"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>`,
+  );
+  zip.file(
+    "Contents/section0.xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<hp:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:p><hp:run charPrIDRef="1"><hp:t>자간 변경 테스트</hp:t></hp:run></hp:p>
+</hp:sec>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer", compression: "DEFLATE" });
+}
+
 describe("applyProseMirrorDocToHwpx table patch", () => {
   it("applies row/col/merge changes by patching table XML fragment", async () => {
     const input = await makeTableFixtureHwpx();
@@ -387,5 +421,56 @@ describe("applyProseMirrorDocToHwpx table patch", () => {
     expect(outXml).toContain("<hp:t>TOP</hp:t>");
     expect(outXml).toContain("<hp:t>C</hp:t>");
     expect(outXml).toContain("<hp:t>D</hp:t>");
+  });
+});
+
+describe("applyProseMirrorDocToHwpx letter spacing patch", () => {
+  it("creates/rewires charPr in header.xml and updates run charPrIDRef by textIndex", async () => {
+    const input = await makeLetterSpacingFixtureHwpx();
+    const parsed = await parseHwpxToProseMirror(input);
+    const doc = JSON.parse(JSON.stringify(parsed.doc)) as JSONContent;
+    const paragraph = (doc.content || []).find((node) => node.type === "paragraph");
+    if (!paragraph) {
+      throw new Error("paragraph not found in fixture");
+    }
+    paragraph.attrs = {
+      ...(paragraph.attrs || {}),
+      letterSpacing: 12,
+    };
+
+    const result = await applyProseMirrorDocToHwpx(input, doc, parsed.segments, parsed.extraSegmentsMap);
+    expect(result.integrityIssues).toEqual([]);
+    expect(result.edits).toEqual([]);
+
+    const outBuffer = await result.blob.arrayBuffer();
+    const outZip = await JSZip.loadAsync(outBuffer);
+    const headerXml = await outZip.file("Contents/header.xml")!.async("string");
+    const sectionXml = await outZip.file("Contents/section0.xml")!.async("string");
+
+    const headerDoc = new DOMParser().parseFromString(headerXml, "application/xml");
+    const charProperties = Array.from(headerDoc.getElementsByTagName("*")).find(
+      (node) => node.localName === "charProperties",
+    );
+    expect(charProperties).toBeTruthy();
+    if (!charProperties) {
+      return;
+    }
+
+    const charPrNodes = Array.from(charProperties.children).filter((child) => child.localName === "charPr");
+    expect(charPrNodes.length).toBe(3);
+    expect(charProperties.getAttribute("itemCnt")).toBe("3");
+
+    const spacing12CharPr = charPrNodes.find((charPr) => {
+      const spacing = Array.from(charPr.children).find((child) => child.localName === "spacing");
+      return spacing?.getAttribute("hangul") === "12";
+    });
+    expect(spacing12CharPr).toBeTruthy();
+    if (!spacing12CharPr) {
+      return;
+    }
+
+    const newCharPrId = spacing12CharPr.getAttribute("id");
+    expect(newCharPrId).toBeTruthy();
+    expect(sectionXml).toContain(`charPrIDRef="${newCharPrId}"`);
   });
 });

--- a/src/lib/editor/prosemirror-to-hwpx.ts
+++ b/src/lib/editor/prosemirror-to-hwpx.ts
@@ -9,6 +9,7 @@ type MetadataAttrs = {
   fileName?: string;
   textIndex?: number;
   originalText?: string;
+  letterSpacing?: number | string;
 };
 
 type TableMetadataAttrs = {
@@ -59,6 +60,21 @@ export type CollectEditsResult = {
   warnings: string[];
 };
 
+type LetterSpacingEdit = {
+  segmentId: string;
+  fileName: string;
+  textIndex: number;
+  sourceCharPrIDRef: string;
+  newSpacing: number;
+};
+
+type CollectLetterSpacingResult = {
+  edits: LetterSpacingEdit[];
+  warnings: string[];
+};
+
+const HEADER_FILE = "Contents/header.xml";
+
 function extractNodeText(node: JSONContent): string {
   if (node.type === "text") {
     return node.text || "";
@@ -102,8 +118,34 @@ function asNonNegativeInt(input: unknown): number | null {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
+function asInt(input: unknown): number | null {
+  if (input === null || input === undefined || input === "") {
+    return null;
+  }
+  const parsed = Number.parseInt(String(input), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function uniqueWarnings(items: string[]): string[] {
   return Array.from(new Set(items));
+}
+
+function readSegmentCharPrIDRef(segment: EditorSegment): string | null {
+  const direct = segment.styleHints.charPrIDRef;
+  if (direct && String(direct).trim()) {
+    return String(direct).trim();
+  }
+  const styleEntries = Object.entries(segment.styleHints);
+  const fallback = styleEntries.find(([key]) => key.toLowerCase() === "charpridref");
+  return fallback && String(fallback[1]).trim() ? String(fallback[1]).trim() : null;
+}
+
+function readSegmentLetterSpacing(segment: EditorSegment): number {
+  const fromHint =
+    asInt(segment.styleHints.hwpxCharSpacing) ??
+    asInt(segment.styleHints.letterSpacing) ??
+    asInt(segment.styleHints.spacing);
+  return fromHint ?? 0;
 }
 
 function isXmlName(fileName: string): boolean {
@@ -634,6 +676,324 @@ async function applyTablePatches(
   };
 }
 
+function readNodeLetterSpacing(attrs: MetadataAttrs): number {
+  return asInt(attrs.letterSpacing) ?? 0;
+}
+
+function collectLetterSpacingEdits(
+  doc: JSONContent,
+  sourceSegments: EditorSegment[],
+  extraSegmentsMap?: Record<string, string[]>,
+): CollectLetterSpacingResult {
+  const bySegmentId = new Map(sourceSegments.map((segment) => [segment.segmentId, segment]));
+  const edits = new Map<string, LetterSpacingEdit>();
+  const warnings: string[] = [];
+
+  const registerEdit = (segment: EditorSegment, nextSpacing: number): void => {
+    const sourceCharPrIDRef = readSegmentCharPrIDRef(segment);
+    if (!sourceCharPrIDRef) {
+      warnings.push(`segment(${segment.segmentId})의 charPrIDRef를 찾지 못해 자간 반영을 건너뜁니다.`);
+      return;
+    }
+    if (readSegmentLetterSpacing(segment) === nextSpacing) {
+      return;
+    }
+    edits.set(segment.segmentId, {
+      segmentId: segment.segmentId,
+      fileName: segment.fileName,
+      textIndex: segment.textIndex,
+      sourceCharPrIDRef,
+      newSpacing: nextSpacing,
+    });
+  };
+
+  walk(doc, (node) => {
+    if (!isTextBlockNode(node)) {
+      return;
+    }
+
+    const attrs = (node.attrs || {}) as MetadataAttrs;
+    const segmentId = attrs.segmentId;
+    if (!segmentId) {
+      return;
+    }
+    const source = bySegmentId.get(segmentId);
+    if (!source) {
+      return;
+    }
+    const nextSpacing = readNodeLetterSpacing(attrs);
+    registerEdit(source, nextSpacing);
+
+    if (extraSegmentsMap) {
+      for (const extraId of extraSegmentsMap[segmentId] || []) {
+        const extra = bySegmentId.get(extraId);
+        if (!extra) {
+          continue;
+        }
+        registerEdit(extra, nextSpacing);
+      }
+    }
+  });
+
+  return {
+    edits: Array.from(edits.values()).sort((a, b) => a.textIndex - b.textIndex),
+    warnings: uniqueWarnings(warnings),
+  };
+}
+
+function closestAncestorByLocalName(element: Element | null, localName: string): Element | null {
+  let current = element;
+  while (current) {
+    if (current.localName === localName) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+function readCharPrSpacing(charPr: Element): number {
+  const spacing = Array.from(charPr.children).find((child) => child.localName === "spacing");
+  if (!spacing) {
+    return 0;
+  }
+  return (
+    asInt(spacing.getAttribute("hangul")) ??
+    asInt(spacing.getAttribute("latin")) ??
+    asInt(spacing.getAttribute("hanja")) ??
+    asInt(spacing.getAttribute("japanese")) ??
+    asInt(spacing.getAttribute("other")) ??
+    asInt(spacing.getAttribute("symbol")) ??
+    asInt(spacing.getAttribute("user")) ??
+    0
+  );
+}
+
+function ensureCharPrSpacingElement(charPr: Element, document: Document): Element {
+  const existing = Array.from(charPr.children).find((child) => child.localName === "spacing");
+  if (existing) {
+    return existing;
+  }
+  const namespaceUri = charPr.namespaceURI || "http://www.hancom.co.kr/hwpml/2011/head";
+  const prefix = charPr.prefix || "hh";
+  const spacing = document.createElementNS(namespaceUri, `${prefix}:spacing`);
+  charPr.appendChild(spacing);
+  return spacing;
+}
+
+function setSpacingAttributes(spacingElement: Element, value: number): void {
+  const serialized = String(value);
+  for (const attr of ["hangul", "latin", "hanja", "japanese", "other", "symbol", "user"]) {
+    spacingElement.setAttribute(attr, serialized);
+  }
+}
+
+async function applyLetterSpacingPatches(
+  fileBuffer: ArrayBuffer,
+  edits: LetterSpacingEdit[],
+  sourceSegments: EditorSegment[],
+): Promise<{ buffer: ArrayBuffer; warnings: string[] }> {
+  if (!edits.length) {
+    return { buffer: fileBuffer, warnings: [] };
+  }
+
+  const zip = await JSZip.loadAsync(fileBuffer);
+  const headerFile = zip.files[HEADER_FILE];
+  if (!headerFile || headerFile.dir) {
+    return {
+      buffer: fileBuffer,
+      warnings: ["Contents/header.xml을 찾지 못해 자간 반영을 건너뜁니다."],
+    };
+  }
+
+  const warnings: string[] = [];
+  const headerXml = await headerFile.async("string");
+  const headerDoc = new DOMParser().parseFromString(headerXml, "application/xml");
+  if (headerDoc.querySelector("parsererror")) {
+    return {
+      buffer: fileBuffer,
+      warnings: ["header.xml 파싱 실패로 자간 반영을 건너뜁니다."],
+    };
+  }
+
+  const charProperties = Array.from(headerDoc.getElementsByTagName("*")).find(
+    (node) => node.localName === "charProperties",
+  );
+  if (!charProperties) {
+    return {
+      buffer: fileBuffer,
+      warnings: ["header.xml에 charProperties가 없어 자간 반영을 건너뜁니다."],
+    };
+  }
+
+  const charPrNodes = Array.from(charProperties.children).filter((child) => child.localName === "charPr");
+  const charPrById = new Map<string, Element>();
+  let maxId = 0;
+  for (const charPr of charPrNodes) {
+    const id = charPr.getAttribute("id");
+    if (!id) {
+      continue;
+    }
+    charPrById.set(id, charPr);
+    const parsed = asInt(id);
+    if (parsed !== null) {
+      maxId = Math.max(maxId, parsed);
+    }
+  }
+  let nextCharPrId = maxId + 1;
+  const charPrCache = new Map<string, string>();
+  const targetCharPrBySegment = new Map<string, string>();
+
+  for (const edit of edits) {
+    const cacheKey = `${edit.sourceCharPrIDRef}::${edit.newSpacing}`;
+    if (charPrCache.has(cacheKey)) {
+      targetCharPrBySegment.set(edit.segmentId, charPrCache.get(cacheKey)!);
+      continue;
+    }
+
+    const sourceCharPr = charPrById.get(edit.sourceCharPrIDRef);
+    if (!sourceCharPr) {
+      warnings.push(
+        `charPr(${edit.sourceCharPrIDRef})를 찾지 못해 segment(${edit.segmentId}) 자간 반영을 건너뜁니다.`,
+      );
+      continue;
+    }
+
+    const sourceSpacing = readCharPrSpacing(sourceCharPr);
+    if (sourceSpacing === edit.newSpacing) {
+      charPrCache.set(cacheKey, edit.sourceCharPrIDRef);
+      targetCharPrBySegment.set(edit.segmentId, edit.sourceCharPrIDRef);
+      continue;
+    }
+
+    const cloned = sourceCharPr.cloneNode(true) as Element;
+    const nextId = String(nextCharPrId);
+    nextCharPrId += 1;
+    cloned.setAttribute("id", nextId);
+    const spacingElement = ensureCharPrSpacingElement(cloned, headerDoc);
+    setSpacingAttributes(spacingElement, edit.newSpacing);
+    charProperties.appendChild(cloned);
+    charPrById.set(nextId, cloned);
+    charPrCache.set(cacheKey, nextId);
+    targetCharPrBySegment.set(edit.segmentId, nextId);
+  }
+
+  if (!targetCharPrBySegment.size) {
+    return {
+      buffer: fileBuffer,
+      warnings: uniqueWarnings(warnings),
+    };
+  }
+
+  const nextCharPrCount = Array.from(charProperties.children).filter((child) => child.localName === "charPr").length;
+  charProperties.setAttribute("itemCnt", String(nextCharPrCount));
+
+  const targetBySegmentId = new Map<string, string>();
+  for (const edit of edits) {
+    const targetCharPrId = targetCharPrBySegment.get(edit.segmentId);
+    if (!targetCharPrId) {
+      continue;
+    }
+    targetBySegmentId.set(edit.segmentId, targetCharPrId);
+  }
+
+  const names = Object.keys(zip.files);
+  const filesToPatch = new Set(edits.map((edit) => edit.fileName));
+  const stagedEntries: Array<{ fileName: string; data: string | Uint8Array }> = [];
+  for (const fileName of names) {
+    const item = zip.files[fileName];
+    if (item.dir) {
+      continue;
+    }
+    if (!isXmlName(fileName)) {
+      stagedEntries.push({ fileName, data: await item.async("uint8array") });
+      continue;
+    }
+    if (fileName === HEADER_FILE) {
+      stagedEntries.push({ fileName, data: new XMLSerializer().serializeToString(headerDoc) });
+      continue;
+    }
+    if (!filesToPatch.has(fileName)) {
+      stagedEntries.push({ fileName, data: await item.async("uint8array") });
+      continue;
+    }
+
+    const sectionXml = await item.async("string");
+    const sectionDoc = new DOMParser().parseFromString(sectionXml, "application/xml");
+    if (sectionDoc.querySelector("parsererror")) {
+      warnings.push(`section XML 파싱 실패로 자간 반영을 건너뜁니다: ${fileName}`);
+      stagedEntries.push({ fileName, data: await item.async("uint8array") });
+      continue;
+    }
+
+    const pool = sourceSegments
+      .filter((segment) => segment.fileName === fileName)
+      .sort((a, b) => a.textIndex - b.textIndex);
+    let poolIndex = 0;
+    const visit = (node: Node): void => {
+      if (node.nodeType === 3 /* TEXT_NODE */ || node.nodeType === 4 /* CDATA_SECTION_NODE */) {
+        const textNode = node as Text;
+        if ((textNode.nodeValue || "").trim().length > 0 && poolIndex < pool.length) {
+          const segment = pool[poolIndex];
+          const targetCharPrId = targetBySegmentId.get(segment.segmentId);
+          if (targetCharPrId) {
+            const run = closestAncestorByLocalName(textNode.parentElement, "run");
+            if (run) {
+              run.setAttribute("charPrIDRef", targetCharPrId);
+            }
+          }
+          poolIndex += 1;
+        }
+        return;
+      }
+      for (const child of Array.from(node.childNodes)) {
+        visit(child);
+      }
+    };
+    visit(sectionDoc);
+
+    stagedEntries.push({
+      fileName,
+      data: new XMLSerializer().serializeToString(sectionDoc),
+    });
+  }
+
+  const out = new JSZip();
+  const map = new Map(stagedEntries.map((entry) => [entry.fileName, entry]));
+  const ordered: Array<{ fileName: string; data: string | Uint8Array }> = [];
+
+  if (map.has("mimetype")) {
+    ordered.push(map.get("mimetype")!);
+    map.delete("mimetype");
+  }
+  for (const entry of stagedEntries) {
+    if (!map.has(entry.fileName)) {
+      continue;
+    }
+    ordered.push(entry);
+    map.delete(entry.fileName);
+  }
+  for (const entry of map.values()) {
+    ordered.push(entry);
+  }
+
+  for (const entry of ordered) {
+    const options = entry.fileName === "mimetype" ? { compression: "STORE" as const } : undefined;
+    out.file(entry.fileName, entry.data, options);
+  }
+
+  const buffer = await out.generateAsync({
+    type: "arraybuffer",
+    compression: "DEFLATE",
+    mimeType: "application/zip",
+  });
+
+  return {
+    buffer,
+    warnings: uniqueWarnings(warnings),
+  };
+}
+
 export function collectDocumentEdits(
   doc: JSONContent,
   sourceSegments: EditorSegment[],
@@ -711,13 +1071,19 @@ export async function applyProseMirrorDocToHwpx(
 ): Promise<{ blob: Blob; edits: TextEdit[]; warnings: string[]; integrityIssues: string[] }> {
   const { edits, warnings: previewWarnings } = collectDocumentEdits(doc, sourceSegments, extraSegmentsMap);
   const { patches: tablePatches, warnings: tableWarnings } = collectTablePatches(doc);
-  if (!edits.length && !tablePatches.length) {
+  const { edits: letterSpacingEdits, warnings: letterSpacingWarnings } = collectLetterSpacingEdits(
+    doc,
+    sourceSegments,
+    extraSegmentsMap,
+  );
+
+  if (!edits.length && !tablePatches.length && !letterSpacingEdits.length) {
     const blob = new Blob([fileBuffer], { type: "application/zip" });
     const integrityIssues = await validateHwpxArchive(fileBuffer);
     return {
       blob,
       edits,
-      warnings: uniqueWarnings([...previewWarnings, ...tableWarnings]),
+      warnings: uniqueWarnings([...previewWarnings, ...tableWarnings, ...letterSpacingWarnings]),
       integrityIssues,
     };
   }
@@ -735,12 +1101,18 @@ export async function applyProseMirrorDocToHwpx(
     runtimeWarnings = patched.warnings;
   }
 
+  if (letterSpacingEdits.length) {
+    const patched = await applyLetterSpacingPatches(workingBuffer, letterSpacingEdits, sourceSegments);
+    workingBuffer = patched.buffer;
+    runtimeWarnings = [...runtimeWarnings, ...patched.warnings];
+  }
+
   const integrityIssues = await validateHwpxArchive(workingBuffer);
   const blob = new Blob([workingBuffer], { type: "application/zip" });
   return {
     blob,
     edits,
-    warnings: uniqueWarnings([...previewWarnings, ...tableWarnings, ...runtimeWarnings]),
+    warnings: uniqueWarnings([...previewWarnings, ...tableWarnings, ...letterSpacingWarnings, ...runtimeWarnings]),
     integrityIssues,
   };
 }

--- a/src/lib/editor/schema.ts
+++ b/src/lib/editor/schema.ts
@@ -1,5 +1,40 @@
 import { Extension } from "@tiptap/core";
 
+function parseLetterSpacingValue(raw: string | null): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseLetterSpacingFromStyle(style: string | null): number | null {
+  if (!style) {
+    return null;
+  }
+  const match = style.match(/letter-spacing\s*:\s*(-?\d+(?:\.\d+)?)em/i);
+  if (!match) {
+    return null;
+  }
+  const em = Number.parseFloat(match[1]);
+  if (!Number.isFinite(em)) {
+    return null;
+  }
+  return Math.round(em * 100);
+}
+
+function renderLetterSpacingAttributes(value: unknown): Record<string, string> {
+  const parsed = parseLetterSpacingValue(value === null || value === undefined ? null : String(value));
+  if (parsed === null) {
+    return {};
+  }
+  const em = (parsed / 100).toFixed(4);
+  return {
+    "data-letter-spacing": String(parsed),
+    style: `letter-spacing: ${em}em`,
+  };
+}
+
 export const HwpxMetadataExtension = Extension.create({
   name: "hwpxMetadata",
   addGlobalAttributes() {
@@ -49,6 +84,18 @@ export const HwpxMetadataExtension = Extension.create({
               }
               return { "data-original-text": String(attributes.originalText) };
             },
+          },
+          letterSpacing: {
+            default: null,
+            parseHTML: (element: HTMLElement) => {
+              const fromData = parseLetterSpacingValue(element.getAttribute("data-letter-spacing"));
+              if (fromData !== null) {
+                return fromData;
+              }
+              return parseLetterSpacingFromStyle(element.getAttribute("style"));
+            },
+            renderHTML: (attributes: Record<string, unknown>) =>
+              renderLetterSpacingAttributes(attributes.letterSpacing),
           },
         },
       },
@@ -187,6 +234,20 @@ export const HwpxMetadataExtension = Extension.create({
                 return {};
               }
               return { "data-source-colspan": String(attributes.sourceColspan) };
+            },
+          },
+          backgroundColor: {
+            default: null,
+            parseHTML: (element: HTMLElement) => element.getAttribute("data-bg-color"),
+            renderHTML: (attributes: Record<string, unknown>) => {
+              if (!attributes.backgroundColor) {
+                return {};
+              }
+              const color = String(attributes.backgroundColor);
+              return {
+                "data-bg-color": color,
+                style: `background-color: ${color};`,
+              };
             },
           },
         },

--- a/src/store/document-store.ts
+++ b/src/store/document-store.ts
@@ -3,8 +3,11 @@ import type { JSONContent } from "@tiptap/core";
 import type { EditorSegment } from "@/lib/editor/hwpx-to-prosemirror";
 import type { TextEdit } from "@/lib/hwpx";
 import type { OutlineItem } from "@/lib/editor/document-store";
+import type { PresetKey } from "@/lib/editor/ai-presets";
 
-export type SidebarTab = "outline" | "ai" | "history";
+import type { ChatMessageUI, PendingToolCall } from "@/types/chat";
+
+export type SidebarTab = "outline" | "ai" | "chat" | "history" | "analysis";
 
 export type RenderElementInfo = {
   segmentId: string;
@@ -22,6 +25,22 @@ export type EditHistoryItem = {
 export type BatchSuggestionItem = {
   id: string;
   suggestion: string;
+};
+
+export type DocumentAnalysis = {
+  documentType: string;
+  suggestedPreset: string;
+  readabilityScore: number;
+  globalIssues: string[];
+  inconsistentTerms: Array<{
+    variants: string[];
+    suggestedTerm: string;
+  }>;
+};
+
+export type VerificationResult = {
+  passed: boolean;
+  issues: string[];
 };
 
 type DownloadState = {
@@ -59,6 +78,26 @@ type DocumentState = {
   renderHtml: string | null;
   renderElementMap: Record<string, RenderElementInfo> | null;
 
+  // Phase 2-1: Accept/Reject
+  batchDecisions: Record<string, "accepted" | "rejected">;
+  // Phase 2-3: Presets
+  selectedPreset: PresetKey;
+  // Phase 2-4: Document Intelligence
+  documentAnalysis: DocumentAnalysis | null;
+  analysisLoading: boolean;
+  // Phase 2-5: Terminology
+  terminologyDict: Record<string, string>;
+  // Phase 2-6: Verification
+  verificationResult: VerificationResult | null;
+  verificationLoading: boolean;
+  // Batch mode
+  batchMode: "section" | "document";
+
+  // Chat agent
+  chatMessages: ChatMessageUI[];
+  chatBusy: boolean;
+  pendingToolCall: PendingToolCall | null;
+
   resetDocument: () => void;
   setLoadedDocument: (params: {
     fileName: string;
@@ -81,10 +120,38 @@ type DocumentState = {
   setSelection: (selection: EditorSelectionState) => void;
   setAiSuggestion: (suggestion: string) => void;
   setBatchSuggestions: (suggestions: BatchSuggestionItem[]) => void;
-  setAiBusy: (isBusy: boolean) => void;
+  setAiBusy: (aiBusy: boolean) => void;
   setDownload: (download: DownloadState) => void;
   setRenderResult: (html: string, elementMap: Record<string, RenderElementInfo>) => void;
   pushHistory: (summary: string, editCount: number) => void;
+
+  // Phase 2-1
+  setBatchDecision: (id: string, decision: "accepted" | "rejected") => void;
+  clearBatchDecisions: () => void;
+  // Phase 2-3
+  setSelectedPreset: (preset: PresetKey) => void;
+  // Phase 2-4
+  setDocumentAnalysis: (analysis: DocumentAnalysis | null) => void;
+  setAnalysisLoading: (loading: boolean) => void;
+  // Phase 2-5
+  setTerminologyDict: (dict: Record<string, string>) => void;
+  updateTerminologyEntry: (variant: string, canonical: string) => void;
+  removeTerminologyEntry: (variant: string) => void;
+  // Phase 2-6
+  setVerificationResult: (result: VerificationResult | null) => void;
+  setVerificationLoading: (loading: boolean) => void;
+  // Batch mode
+  setBatchMode: (mode: "section" | "document") => void;
+
+  // Chat agent
+  addChatMessage: (msg: ChatMessageUI) => void;
+  updateLastAssistantMessage: (fn: (prev: string) => string) => void;
+  finalizeLastAssistantMessage: () => void;
+  setChatBusy: (busy: boolean) => void;
+  setPendingToolCall: (pending: PendingToolCall | null) => void;
+  clearChat: () => void;
+  appendToolCallToLastMessage: (tc: import("@/types/chat").ToolCallInfo) => void;
+  appendToolResultToLastMessage: (tr: import("@/types/chat").ToolResultInfo) => void;
 };
 
 const INITIAL_INSTRUCTION = "문장을 간결하게 다듬고 기술 문서 톤으로 수정해줘.";
@@ -105,7 +172,7 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   outline: [],
   editsPreview: [],
   history: [],
-  status: "HWPX 파일을 업로드하세요.",
+  status: "HWPX 또는 DOCX 파일을 업로드하세요.",
   isBusy: false,
   isDirty: false,
   sidebarCollapsed: false,
@@ -122,6 +189,19 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   renderHtml: null,
   renderElementMap: null,
 
+  batchDecisions: {},
+  selectedPreset: "custom",
+  documentAnalysis: null,
+  analysisLoading: false,
+  terminologyDict: {},
+  verificationResult: null,
+  verificationLoading: false,
+  batchMode: "section",
+
+  chatMessages: [],
+  chatBusy: false,
+  pendingToolCall: null,
+
   resetDocument: () =>
     set({
       fileName: "",
@@ -137,10 +217,20 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
       selection: { selectedSegmentId: null, selectedText: "" },
       aiSuggestion: "",
       batchSuggestions: [],
+      batchDecisions: {},
+      documentAnalysis: null,
+      analysisLoading: false,
+      terminologyDict: {},
+      verificationResult: null,
+      verificationLoading: false,
+      batchMode: "section",
+      chatMessages: [],
+      chatBusy: false,
+      pendingToolCall: null,
       download: initialDownload,
       renderHtml: null,
       renderElementMap: null,
-      status: "HWPX 파일을 업로드하세요.",
+      status: "HWPX 또는 DOCX 파일을 업로드하세요.",
       history: [],
     }),
 
@@ -157,6 +247,12 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
       isDirty: false,
       aiSuggestion: "",
       batchSuggestions: [],
+      batchDecisions: {},
+      documentAnalysis: null,
+      terminologyDict: {},
+      verificationResult: null,
+      verificationLoading: false,
+      batchMode: "section",
       selection: { selectedSegmentId: null, selectedText: "" },
       download: {
         blob: null,
@@ -195,4 +291,94 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
         ...state.history,
       ].slice(0, 100),
     })),
+
+  // Phase 2-1: Accept/Reject
+  setBatchDecision: (id, decision) =>
+    set((state) => ({
+      batchDecisions: { ...state.batchDecisions, [id]: decision },
+    })),
+  clearBatchDecisions: () => set({ batchDecisions: {} }),
+
+  // Phase 2-3: Presets
+  setSelectedPreset: (selectedPreset) => set({ selectedPreset }),
+
+  // Phase 2-4: Document Intelligence
+  setDocumentAnalysis: (documentAnalysis) => set({ documentAnalysis }),
+  setAnalysisLoading: (analysisLoading) => set({ analysisLoading }),
+
+  // Phase 2-5: Terminology
+  setTerminologyDict: (terminologyDict) => set({ terminologyDict }),
+  updateTerminologyEntry: (variant, canonical) =>
+    set((state) => ({
+      terminologyDict: { ...state.terminologyDict, [variant]: canonical },
+    })),
+  removeTerminologyEntry: (variant) =>
+    set((state) => {
+      const next = { ...state.terminologyDict };
+      delete next[variant];
+      return { terminologyDict: next };
+    }),
+
+  // Phase 2-6: Verification
+  setVerificationResult: (verificationResult) => set({ verificationResult }),
+  setVerificationLoading: (verificationLoading) => set({ verificationLoading }),
+
+  // Batch mode
+  setBatchMode: (batchMode) => set({ batchMode }),
+
+  // Chat agent
+  addChatMessage: (msg) =>
+    set((state) => ({ chatMessages: [...state.chatMessages, msg] })),
+
+  updateLastAssistantMessage: (fn) =>
+    set((state) => {
+      const msgs = [...state.chatMessages];
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].role === "assistant") {
+          msgs[i] = { ...msgs[i], content: fn(msgs[i].content) };
+          break;
+        }
+      }
+      return { chatMessages: msgs };
+    }),
+
+  finalizeLastAssistantMessage: () =>
+    set((state) => {
+      const msgs = [...state.chatMessages];
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].role === "assistant") {
+          msgs[i] = { ...msgs[i], isStreaming: false };
+          break;
+        }
+      }
+      return { chatMessages: msgs };
+    }),
+
+  setChatBusy: (chatBusy) => set({ chatBusy }),
+  setPendingToolCall: (pendingToolCall) => set({ pendingToolCall }),
+  clearChat: () => set({ chatMessages: [], pendingToolCall: null, chatBusy: false }),
+
+  appendToolCallToLastMessage: (tc) =>
+    set((state) => {
+      const msgs = [...state.chatMessages];
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].role === "assistant") {
+          msgs[i] = { ...msgs[i], toolCalls: [...(msgs[i].toolCalls || []), tc] };
+          break;
+        }
+      }
+      return { chatMessages: msgs };
+    }),
+
+  appendToolResultToLastMessage: (tr) =>
+    set((state) => {
+      const msgs = [...state.chatMessages];
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].role === "assistant") {
+          msgs[i] = { ...msgs[i], toolResults: [...(msgs[i].toolResults || []), tr] };
+          break;
+        }
+      }
+      return { chatMessages: msgs };
+    }),
 }));

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,88 @@
+export type ChatRole = "user" | "assistant";
+
+export type ToolCallInfo = {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+
+export type ToolResultInfo = {
+  toolCallId: string;
+  name: string;
+  result: unknown;
+  isAutoExecuted: boolean;
+};
+
+export type EditPreviewItem = {
+  segmentId: string;
+  before: string;
+  after: string;
+};
+
+export type EditPreview = {
+  edits: EditPreviewItem[];
+  summary: string;
+};
+
+export type PendingToolCall = {
+  toolCall: ToolCallInfo;
+  preview: EditPreview | null;
+};
+
+export type ChatMessageUI = {
+  id: string;
+  role: ChatRole;
+  content: string;
+  timestamp: number;
+  toolCalls?: ToolCallInfo[];
+  toolResults?: ToolResultInfo[];
+  isStreaming?: boolean;
+};
+
+/**
+ * Sent to /api/chat as POST body.
+ */
+export type ChatRequest = {
+  messages: ChatMessageAPI[];
+  documentContext: DocumentContext;
+  approvedToolCall?: ApprovedToolCall;
+};
+
+export type ChatMessageAPI = {
+  role: "user" | "assistant";
+  content: string | ContentBlock[];
+};
+
+export type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+  | { type: "tool_result"; tool_use_id: string; content: string };
+
+export type DocumentContext = {
+  segments: DocumentContextSegment[];
+  fileName: string;
+};
+
+export type DocumentContextSegment = {
+  segmentId: string;
+  text: string;
+  tag: string;
+  styleHints: Record<string, string>;
+};
+
+export type ApprovedToolCall = {
+  toolCallId: string;
+  toolName: string;
+  result: string;
+};
+
+/**
+ * SSE event types from /api/chat
+ */
+export type SSEEvent =
+  | { type: "text_delta"; content: string }
+  | { type: "tool_call"; toolCall: ToolCallInfo }
+  | { type: "tool_result"; result: ToolResultInfo }
+  | { type: "tool_pending"; toolCall: ToolCallInfo }
+  | { type: "done"; usage: { inputTokens: number; outputTokens: number } }
+  | { type: "error"; message: string };


### PR DESCRIPTION
## 초록 (Abstract)
코어 구현 이후 실제 사용자 흐름(업로드 -> 분석/채팅 -> 편집 -> 저장)에 맞춰 워크플로우를 재구성했다. API 계층, 입력 변환 경로(DOCX/PPTX), 편집 레이아웃을 확장하여 기능 단위 성공을 사용자 시나리오 단위 성공으로 연결하는 것이 목적이다.

## 연구 질문
1. AI/채팅/문서분석/편집을 동시 사용해도 상태 일관성을 유지할 수 있는가?
2. DOCX/PPTX 입력 확장이 저장 파이프라인 회귀를 증가시키지 않는가?

## 방법 (Method)
1. API 확장: `/api/chat`, `/api/analyze-document`, `/api/verify`
2. 편집 레이아웃 분해: 룰러/스타일 모달/사이드바 탭 구조 도입
3. 변환 경로 확장: DOCX/PPTX -> ProseMirror, DOCX/PDF export 추가
4. 워크플로우 store 정리로 UI 이벤트 타이밍 경합 완화

## 시행착오와 교정
1. API 먼저 확장 시 UI 상태 경합 증가
교정: 이벤트 경계를 editor workflow/store로 재정의.

2. 변환 문서 attrs 누락으로 저장 실패 가능
교정: schema/extensions에서 보존 attrs 명시.

## 정량 스코프
| 항목 | 값 |
|---|---:|
| Base | `pr/phase1-core-editor` |
| Head | `pr/phase2-workflow-overhaul` |
| 파일 변경 | 46 |
| 코드 추가/삭제 | +7,154 / -509 |
| 핵심 커밋 | `b5e4cfb` |

## 실험/검증 프로토콜
1. 워크플로우 테스트(편집 세션/제안 적용) 회귀 점검
2. 변환 입력 문서의 기본 편집/저장 경로 확인
3. API 응답 기반 UI 패널 전환/상태 전파 확인

## 타당도 위협 (Threats to Validity)
1. 모델 응답 품질은 외부 API/프롬프트 편차에 영향 받음.
2. 변환 포맷 fidelity는 문서 유형별 편차 존재.

## 재현 절차
```bash
git checkout pr/phase2-workflow-overhaul
npm ci
npm test
```

## 리뷰 체크리스트
1. API 핸들러 책임 분리가 과도 결합 없이 유지되는지
2. 변환 attrs가 저장 경로까지 일관되게 전달되는지
3. 패널/툴바 확장이 이후 서식 PR과 충돌하지 않는지

## 스택 연결
- 이전 단계: PR #2 (`pr/phase1-core-editor`)
- 다음 단계: PR #4 (`pr/phase3-formatting-roundtrip`)


## Reviewed-by Checklist
- [ ] 연구 질문/목표가 코드 변경과 직접 대응한다.
- [ ] 시행착오(실패 사례)와 수정 전략이 코드 diff로 추적 가능하다.
- [ ] 정량 스코프(파일 수, +/- 라인)와 `git diff --shortstat` 결과가 일치한다.
- [ ] 재현 절차(`npm test`)를 실행해 동일 결과를 확인했다.
- [ ] 스택 PR의 base/head 관계가 올바르다.
